### PR TITLE
Avoid unnecessary use of oneOf

### DIFF
--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -46,7 +46,7 @@
           	"title": "Formation",
             "description": "The activities undertaken in order to enter into a contract.",
             "type": "object",
-            "oneOf": [{ "$ref": "#/definitions/tender" }]
+            "$ref": "#/definitions/tender"
         },
         "awards": { "title": "Awards",
             "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",


### PR DESCRIPTION
Using `oneOf` makes any validation errors within the subschema more opaque in most validators (most validators simply say that none of the `oneOf` subschema validated, not the specific validation errors).
