### PR TITLE
There is no statusDescription field in any version of the standard

### DIFF
--- a/standard/schema/codelists/awardStatus.csv
+++ b/standard/schema/codelists/awardStatus.csv
@@ -2,4 +2,4 @@ Category,Code,Title_en,Description_en,Source
 ,pending,Pending,"This award has been proposed, but is not yet in force. This may be due to a cooling off period, or some other process.",
 ,active,Active,"This award has been made, and is currently in force.",
 ,cancelled,Cancelled,This award has been cancelled.,
-,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers). The reason that the award did not suceed will be given in the statusDescription field.",
+,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers).",


### PR DESCRIPTION
It would be useful to have an awardStatusDetails (as free text) to add information about why an award was unsuccessful or anything related with the status but so far we don't have it.
