### PR TITLE
Fixing links to documentation in the schema

### DIFF
--- a/standard/schema/record-package-schema.json
+++ b/standard/schema/record-package-schema.json
@@ -74,7 +74,7 @@
             "properties": {
                 "ocid": {
                     "title": "Open Contracting ID",
-                    "description": "A unique identifier that identifies the unique Open Contracting Process. For more information see: http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/definitions/#contracting-process",
+                    "description": "A unique identifier that identifies the unique Open Contracting Process. For more information see: http://standard.open-contracting.org/latest/en/getting_started/contracting_process/",
                     "type": "string"
                 },
                 "releases": {
@@ -89,7 +89,7 @@
                                 "type": "object",
                                 "properties": {
                                     "url": {
-                                        "description": "The url of the release which contains the url of the package with the releaseID appended using a fragment identifier e.g. http://ocds.open-contracting.org/demos/releases/12345.json#ocds-a2ef3d01-1594121/1",
+                                        "description": "The url of the release which contains the url of the package with the releaseID appended using a fragment identifier e.g. http://standard.open-contracting.org/latest/en/examples/tender.json#ocds-213czf-000-00001",
                                         "type": ["string", "null"],
                                         "format" : "uri"
                                     },

--- a/standard/schema/release-package-schema.json
+++ b/standard/schema/release-package-schema.json
@@ -52,7 +52,7 @@
             "format": "uri"
         },
         "publicationPolicy": {
-            "description": "A link to a document describing the publishers [publication policy](http://ocds.open-contracting.org/standard/r/1__0__0/en/implementation/publication_patterns/#publication-policy).",
+            "description": "A link to a document describing the publishers [publication policy](http://standard.open-contracting.org/latest/en/implementation/publication_policy/).",
             "type": ["string", "null"],
             "format": "uri"
         }

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -287,7 +287,7 @@
                 },
                 "status": {
                     "title": "Award Status",
-                    "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#award-status)",
+                    "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
                     "type": ["string", "null"],
                     "enum": ["pending", "active", "cancelled", "unsuccessful"],
                     "mergeStrategy": "ocdsVersion"
@@ -375,7 +375,7 @@
                 },
                 "status": {
                     "title": "Contract Status",
-                    "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#contract-status)",
+                    "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
                     "type": ["string", "null"],
                     "enum": ["pending", "active", "cancelled", "terminated"],
                     "mergeStrategy": "ocdsVersion"
@@ -820,7 +820,7 @@
             "type": "object",
             "properties": {
                 "scheme": {
-                    "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible.",
+                    "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible.",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },
@@ -851,7 +851,7 @@
             "type": "object",
             "properties": {
                 "scheme": {
-                    "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme).",
+                    "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -6,7 +6,7 @@
     "properties": {
         "ocid": {
             "title": "Open Contracting ID",
-            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#ocid)",
+            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)",
             "type": "string",
             "mergeStrategy": "ocdsOmit"
         },
@@ -25,7 +25,7 @@
         },
         "tag": {
             "title": "Release Tag",
-            "description": "A value from the [releaseTag codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
+            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
             "type": "array",
             "items": {
                 "type": "string",
@@ -35,7 +35,7 @@
         },
         "initiationType": {
             "title": "Initiation type",
-            "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#initiation-type) codelist. Currently only tender is supported.",
+            "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
             "type": "string",
             "enum": ["tender"],
             "mergeStrategy": "ocdsVersion"
@@ -132,7 +132,7 @@
                 },
                 "status": {
                     "title": "Tender Status",
-                    "description": "The current status of the tender based on the [tenderStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#tender-status)",
+                    "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
                     "type": ["string", "null"],
                     "enum": ["planned", "active", "cancelled", "unsuccessful", "complete", null],
                     "mergeStrategy": "ocdsVersion"
@@ -155,7 +155,7 @@
                     "$ref": "#/definitions/Value"
                 },
                 "procurementMethod": {
-                    "description": "Specify tendering method against the [method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                    "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
                     "type": ["string", "null"],
                     "enum": ["open", "selective", "limited", null],
                     "mergeStrategy": "ocdsVersion"
@@ -166,7 +166,7 @@
                     "mergeStrategy": "ocdsVersion"
                 },
                 "awardCriteria": {
-                    "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#award-criteria)",
+                    "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },
@@ -176,7 +176,7 @@
                     "mergeStrategy": "ocdsVersion"
                 },
                 "submissionMethod": {
-                    "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#submission-method)",
+                    "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
                     "type": ["array", "null"],
                     "items": {
                         "type": "string"
@@ -227,7 +227,7 @@
                     "$ref": "#/definitions/Organization"
                 },
                 "documents": {
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#document-type) for details of potential documents to include.",
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
                     "type": "array",
                     "mergeStrategy": "arrayMergeById",
                     "mergeOptions": { "idRef": "id" },
@@ -271,7 +271,7 @@
             "properties": {
                 "id": {
                     "title": "Award ID",
-                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/) for further details.",
+                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
                     "type": ["string", "integer"],
                     "mergeStrategy": "overwrite"
                 },
@@ -287,7 +287,7 @@
                 },
                 "status": {
                     "title": "Award Status",
-                    "description": "The current status of the award drawn from the [awardStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#award-status)",
+                    "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#award-status)",
                     "type": ["string", "null"],
                     "enum": ["pending", "active", "cancelled", "unsuccessful"],
                     "mergeStrategy": "ocdsVersion"
@@ -353,7 +353,7 @@
             "properties": {
                 "id": {
                     "title": "Contract ID",
-                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/) for further details.",
+                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
                     "type": ["string", "integer"],
                     "mergeStrategy": "overwrite"
                 },
@@ -375,7 +375,7 @@
                 },
                 "status": {
                     "title": "Contract Status",
-                    "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#contract-status)",
+                    "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#contract-status)",
                     "type": ["string", "null"],
                     "enum": ["pending", "active", "cancelled", "terminated"],
                     "mergeStrategy": "ocdsVersion"
@@ -493,7 +493,7 @@
                     "mergeStrategy": "ocdsVersion"
                 },
                 "status": {
-                    "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#milestone-status).",
+                    "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status).",
                     "type": ["string", "null"],
                     "enum": ["met", "notMet", "partiallyMet", null],
                     "mergeStrategy": "ocdsVersion"
@@ -528,7 +528,7 @@
                     "mergeStrategy": "overwrite"
                 },
                 "documentType": {
-                    "description": "A classification of the document described taken from the [documentType codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
+                    "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },
@@ -691,11 +691,11 @@
             "type": "object",
             "properties": {
                 "identifier": { 
-                    "description": "The primary identifier for this organization. Identifiers that uniquely pick out a legal entity should be preferred. Consult the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers) for the preferred scheme and identifier to use.",
+                    "description": "The primary identifier for this organization. Identifiers that uniquely pick out a legal entity should be preferred. Consult the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for the preferred scheme and identifier to use.",
                     "$ref": "#/definitions/Identifier" 
                 },
                 "additionalIdentifiers": { 
-                    "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                    "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
                     "type": "array",
                     "mergeStrategy": "ocdsVersion",
                     "items": { "$ref": "#/definitions/Identifier" },
@@ -731,11 +731,11 @@
                     "type": ["string", "null"]
                 },
                 "classification": {
-                    "description": "The primary classification for the item. See the [itemClassificationScheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#item-classification-scheme) to identify preferred classification lists, including CPV and GSIN.",
+                    "description": "The primary classification for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) to identify preferred classification lists, including CPV and GSIN.",
                     "$ref": "#/definitions/Classification"
                 },
                 "additionalClassifications": {
-                    "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
+                    "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
                     "type": "array",
                     "mergeStrategy": "ocdsVersion",
                     "items": { "$ref": "#/definitions/Classification" },
@@ -820,7 +820,7 @@
             "type": "object",
             "properties": {
                 "scheme": {
-                    "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#item-classification-scheme) wherever possible.",
+                    "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible.",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },
@@ -851,7 +851,7 @@
             "type": "object",
             "properties": {
                 "scheme": {
-                    "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme).",
+                    "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme).",
                     "type": ["string", "null"],
                     "mergeStrategy": "ocdsVersion"
                 },

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -1,178 +1,29 @@
 {
+    "type": "object",
     "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
-    "properties": {
-        "date": {
-            "title": "Release Date",
-            "format": "date-time",
-            "type": "string",
-            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order."
-        },
-        "id": {
-            "title": "Release ID",
-            "type": "string",
-            "description": "A unique identifier that identifies this release. A releaseID must be unique within a release-package and must not contain the # character."
-        },
-        "ocid": {
-            "title": "Open Contracting ID",
-            "type": "string",
-            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#ocid)"
-        },
-        "buyer": {
-            "title": "Organization",
+    "title": "Schema for a compiled, versioned Open Contracting Release.",
+    "definitions": {
+        "Value": {
+            "type": "object",
             "properties": {
-                "contactPoint": {
-                    "properties": {
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "additionalIdentifiers": {
+                "amount": {
                     "type": "array",
                     "items": {
                         "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                },
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true
+                                "minimum": 0,
+                                "type": [
+                                    "number",
+                                    "null"
+                                ],
+                                "description": "Amount as a number."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "releaseTag": {
                                 "type": "string"
@@ -180,125 +31,10 @@
                         }
                     }
                 },
-                "identifier": {
-                    "properties": {
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "name": {
+                "currency": {
                     "type": "array",
                     "items": {
                         "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
                             "releaseID": {
                                 "type": "string"
                             },
@@ -307,171 +43,28 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                                "description": "The currency in 3-letter ISO 4217 format."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "releaseTag": {
                                 "type": "string"
                             }
                         }
                     }
-                },
-                "address": {
-                    "properties": {
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "region": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "An organization.",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
                 }
             }
         },
-        "planning": {
+        "Planning": {
             "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
             "properties": {
                 "rationale": {
                     "type": "array",
                     "items": {
                         "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
                             "releaseID": {
                                 "type": "string"
                             },
@@ -482,6 +75,10 @@
                                 ],
                                 "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
                             },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
                             "releaseTag": {
                                 "type": "string"
                             }
@@ -490,88 +87,85 @@
                 },
                 "documents": {
                     "type": "array",
+                    "description": "A list of documents related to the planning process.",
                     "items": {
                         "$ref": "#/definitions/Document"
-                    },
-                    "description": "A list of documents related to the planning process."
+                    }
                 },
                 "budget": {
                     "type": "array",
                     "items": {
                         "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
+                                "type": "object",
                                 "title": "Budget Information",
+                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
                                 "properties": {
+                                    "source": {
+                                        "format": "uri",
+                                        "title": "Data Source",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
                                     "id": {
-                                        "mergeStrategy": "ocdsVersion",
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
                                         ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
-                                    },
-                                    "source": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Data Source",
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                                    },
-                                    "uri": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Linked budget information",
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process."
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                                        "mergeStrategy": "ocdsVersion"
                                     },
                                     "amount": {
-                                        "description": "The value of the budget line item.",
-                                        "$ref": "#/definitions/Value"
+                                        "$ref": "#/definitions/Value",
+                                        "description": "The value of the budget line item."
+                                    },
+                                    "uri": {
+                                        "format": "uri",
+                                        "title": "Linked budget information",
+                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "description": {
+                                        "title": "Budget Source",
+                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
                                     },
                                     "projectID": {
-                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Project Identifier",
+                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
                                         ],
-                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects."
-                                    },
-                                    "description": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Budget Source",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project."
+                                        "mergeStrategy": "ocdsVersion"
                                     },
                                     "project": {
-                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
                                         "type": [
                                             "string",
                                             "null"
                                         ],
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above."
+                                        "mergeStrategy": "ocdsVersion"
                                     }
                                 },
-                                "type": "object",
                                 "patternProperties": {
                                     "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                                         "type": [
@@ -591,8 +185,11 @@
                                             "null"
                                         ]
                                     }
-                                },
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information."
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "releaseTag": {
                                 "type": "string"
@@ -602,7 +199,6 @@
                 }
             },
             "type": "object",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
@@ -612,8 +208,6294 @@
                 }
             }
         },
+        "Transaction": {
+            "type": "object",
+            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data.",
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
+                },
+                "amount": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "uri": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Linked spending information",
+                                "format": "uri",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A URI pointing directly to a machine-readable record about this spending transaction."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "providerOrganization": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "uri": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "legalName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "scheme": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "receiverOrganization": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "uri": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "legalName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "scheme": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "date": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The date of the transaction"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "source": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Data Source",
+                                "format": "uri",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "title": "Transaction Information",
+            "required": [
+                "id"
+            ]
+        },
+        "Contract": {
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Contract",
+            "description": "Information regarding the signed contract between the buyer and supplier(s).",
+            "properties": {
+                "period": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                },
+                "value": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "description": "All documents and attachments related to the contract, including any notices.",
+                    "uniqueItems": true
+                },
+                "id": {
+                    "title": "Contract ID",
+                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "implementation": {
+                    "type": "object",
+                    "description": "Information during the performance / implementation stage of the contract.",
+                    "properties": {
+                        "milestones": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Milestone"
+                            },
+                            "description": "As milestones are completed, milestone completions should be documented.",
+                            "uniqueItems": true
+                        },
+                        "transactions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Transaction"
+                            },
+                            "description": "A list of the spending transactions made against this contract",
+                            "uniqueItems": true
+                        },
+                        "documents": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Document"
+                            },
+                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                            "uniqueItems": true
+                        }
+                    },
+                    "title": "Implementation"
+                },
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Contract Status",
+                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#contract-status)",
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "terminated"
+                                ],
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "awardID": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award ID",
+                                "description": "The award.id against which this contract is being issued.",
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "dateSigned": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Contract title"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Contract description"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "items": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "title": "Items Contracted",
+                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "amendment": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "rationale": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "date": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The data of this amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Amendment information"
+                }
+            },
+            "required": [
+                "id",
+                "awardID"
+            ]
+        },
+        "Implementation": {
+            "type": "object",
+            "description": "Information during the performance / implementation stage of the contract.",
+            "properties": {
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "description": "As milestones are completed, milestone completions should be documented.",
+                    "uniqueItems": true
+                },
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Transaction"
+                    },
+                    "description": "A list of the spending transactions made against this contract",
+                    "uniqueItems": true
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                    "uniqueItems": true
+                }
+            },
+            "title": "Implementation"
+        },
+        "Milestone": {
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "properties": {
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status).",
+                                "enum": [
+                                    "met",
+                                    "notMet",
+                                    "partiallyMet",
+                                    null
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "dueDate": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The date the milestone is due."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "documents": {
+                    "type": "array",
+                    "description": "List of documents associated with this milestone.",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Milestone title"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of the milestone."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "dateModified": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "Amendment": {
+            "type": "object",
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "properties": {
+                "changes": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Amended fields",
+                                "description": "Comma-seperated list of affected fields.",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "property": {
+                                            "type": "string",
+                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                        },
+                                        "former_value": {
+                                            "type": [
+                                                "string",
+                                                "number",
+                                                "integer",
+                                                "array",
+                                                "object",
+                                                "null"
+                                            ],
+                                            "description": "The previous value of the changed property, in whatever type the property is."
+                                        }
+                                    }
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "rationale": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "An explanation for the amendment."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "date": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Amendment Date",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The data of this amendment."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "title": "Amendment information"
+        },
+        "Identifier": {
+            "type": "object",
+            "patternProperties": {
+                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "properties": {
+                "uri": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uri",
+                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "legalName": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The legally registered name of the organization."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "scheme": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The identifier of the organization in the selected scheme."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Address": {
+            "type": "object",
+            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+            "properties": {
+                "postalCode": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The postal code. For example, 94043."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "streetAddress": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "countryName": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The country name. For example, United States."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "locality": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The locality. For example, Mountain View."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "region": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The region. For example, CA."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "Budget": {
+            "type": "object",
+            "mergeStrategy": "ocdsVersion",
+            "title": "Budget Information",
+            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+            "properties": {
+                "source": {
+                    "format": "uri",
+                    "title": "Data Source",
+                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "mergeStrategy": "ocdsVersion"
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ],
+                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                    "mergeStrategy": "ocdsVersion"
+                },
+                "amount": {
+                    "$ref": "#/definitions/Value",
+                    "description": "The value of the budget line item."
+                },
+                "uri": {
+                    "format": "uri",
+                    "title": "Linked budget information",
+                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "mergeStrategy": "ocdsVersion"
+                },
+                "description": {
+                    "title": "Budget Source",
+                    "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "mergeStrategy": "ocdsVersion"
+                },
+                "projectID": {
+                    "title": "Project Identifier",
+                    "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ],
+                    "mergeStrategy": "ocdsVersion"
+                },
+                "project": {
+                    "title": "Project Title",
+                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "mergeStrategy": "ocdsVersion"
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "Item": {
+            "type": "object",
+            "description": "A good, service, or work to be contracted.",
+            "properties": {
+                "additionalClassifications": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Classification"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "unit": {
+                    "type": "object",
+                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit.",
+                    "properties": {
+                        "value": {
+                            "type": "object",
+                            "properties": {
+                                "amount": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "minimum": 0,
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ],
+                                                "description": "Amount as a number."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "currency": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The currency in 3-letter ISO 4217 format."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Name of the unit"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "quantity": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "minimum": 0,
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The number of units required"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
+                },
+                "classification": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "uri": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A textual description or title for the code."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "scheme": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The classification code drawn from the selected scheme."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of the goods, services to be provided."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "Document": {
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Document",
+            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
+            "properties": {
+                "url": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uri",
+                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "language": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "format": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "documentType": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The document title."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "dateModified": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "Date that the document was last modified"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "datePublished": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "Award": {
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Award",
+            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "properties": {
+                "value": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award Status",
+                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#award-status)",
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful"
+                                ],
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "amendment": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "rationale": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "date": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The data of this amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Amendment information"
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "description": "All documents and attachments related to the award, including any notices.",
+                    "uniqueItems": true
+                },
+                "id": {
+                    "title": "Award ID",
+                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Award title"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Award description"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "suppliers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "date": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award date",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The date of the contract award. This is usually the date on which a decision to award was made."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "items": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "title": "Items Awarded",
+                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "contractPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "Period": {
+            "type": "object",
+            "properties": {
+                "endDate": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The end date for the period."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "startDate": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time",
+                                "description": "The start date for the period."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "title": "Period"
+        },
+        "Classification": {
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "properties": {
+                "uri": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uri",
+                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A textual description or title for the code."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "scheme": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The classification code drawn from the selected scheme."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Organization": {
+            "title": "Organization",
+            "description": "An organization.",
+            "properties": {
+                "additionalIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "address": {
+                    "type": "object",
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                    "properties": {
+                        "postalCode": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The postal code. For example, 94043."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "streetAddress": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "countryName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The country name. For example, United States."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "locality": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The locality. For example, Mountain View."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "region": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The region. For example, CA."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "contactPoint": {
+                    "type": "object",
+                    "description": "An person, contact point or department to contact in relation to this contracting process.",
+                    "properties": {
+                        "telephone": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "email": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The e-mail address of the contact point/person."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "faxNumber": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "url": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A web address for the contact point/person."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "identifier": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "uri": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "legalName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "scheme": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ContactPoint": {
+            "type": "object",
+            "description": "An person, contact point or department to contact in relation to this contracting process.",
+            "properties": {
+                "telephone": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "email": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The e-mail address of the contact point/person."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "faxNumber": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The fax number of the contact point/person. This should include the international dialling code."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "url": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uri",
+                                "description": "A web address for the contact point/person."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "Tender": {
+            "type": "object",
+            "patternProperties": {
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Tender",
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
+            "properties": {
+                "value": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "documents": {
+                    "type": "array",
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }
+                },
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
+                                "enum": [
+                                    "planned",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    "complete",
+                                    null
+                                ],
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tenderers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "All entities who submit a tender.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "awardCriteriaDetails": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the award or selection criteria."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "numberOfTenderers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "definition": "The number of entities who submit a tender."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enquiryPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                },
+                "submissionMethodDetails": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "procurementMethod": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                                "enum": [
+                                    "open",
+                                    "selective",
+                                    "limited",
+                                    null
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "items": {
+                    "type": "array",
+                    "title": "Items to be procured",
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender description"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "amendment": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "rationale": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "date": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The data of this amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Amendment information"
+                },
+                "hasEnquiries": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "eligibilityCriteria": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of any eligibility criteria for potential suppliers."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "awardPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                },
+                "minValue": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "awardCriteria": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "procuringEntity": {
+                    "title": "Organization",
+                    "description": "An organization.",
+                    "properties": {
+                        "additionalIdentifiers": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "array",
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "address": {
+                            "type": "object",
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                            "properties": {
+                                "postalCode": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The postal code. For example, 94043."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "streetAddress": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "countryName": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The country name. For example, United States."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "locality": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The locality. For example, Mountain View."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "region": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The region. For example, CA."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "contactPoint": {
+                            "type": "object",
+                            "description": "An person, contact point or department to contact in relation to this contracting process.",
+                            "properties": {
+                                "telephone": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "email": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The e-mail address of the contact point/person."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "faxNumber": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "format": "uri",
+                                                "description": "A web address for the contact point/person."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "identifier": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "properties": {
+                                "uri": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "format": "uri",
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "legalName": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The legally registered name of the organization."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "scheme": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "id": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ],
+                                                "description": "The identifier of the organization in the selected scheme."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "milestones": {
+                    "type": "array",
+                    "description": "A list of milestones associated with the tender.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    }
+                },
+                "procurementMethodRationale": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender title"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "submissionMethod": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "array",
+                                    "null"
+                                ],
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tenderPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        }
+    },
+    "properties": {
+        "language": {
+            "type": "array",
+            "items": {
+                "properties": {
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Release language",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended.",
+                        "default": "en"
+                    },
+                    "releaseDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "releaseTag": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "tender": {
+            "type": "object",
+            "patternProperties": {
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "title": "Tender",
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
+            "properties": {
+                "value": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "documents": {
+                    "type": "array",
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }
+                },
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "status": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
+                                "enum": [
+                                    "planned",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    "complete",
+                                    null
+                                ],
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tenderers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "All entities who submit a tender.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "awardCriteriaDetails": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the award or selection criteria."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "numberOfTenderers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "definition": "The number of entities who submit a tender."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enquiryPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                },
+                "submissionMethodDetails": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "procurementMethod": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                                "enum": [
+                                    "open",
+                                    "selective",
+                                    "limited",
+                                    null
+                                ]
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "items": {
+                    "type": "array",
+                    "title": "Items to be procured",
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "description": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender description"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "amendment": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "rationale": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "date": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The data of this amendment."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Amendment information"
+                },
+                "hasEnquiries": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "eligibilityCriteria": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of any eligibility criteria for potential suppliers."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "awardPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                },
+                "minValue": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "currency": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "awardCriteria": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "procuringEntity": {
+                    "title": "Organization",
+                    "description": "An organization.",
+                    "properties": {
+                        "additionalIdentifiers": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "array",
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                        "uniqueItems": true,
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        }
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "address": {
+                            "type": "object",
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                            "properties": {
+                                "postalCode": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The postal code. For example, 94043."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "streetAddress": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "countryName": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The country name. For example, United States."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "locality": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The locality. For example, Mountain View."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "region": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The region. For example, CA."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "contactPoint": {
+                            "type": "object",
+                            "description": "An person, contact point or department to contact in relation to this contracting process.",
+                            "properties": {
+                                "telephone": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "email": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The e-mail address of the contact point/person."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "faxNumber": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "url": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "format": "uri",
+                                                "description": "A web address for the contact point/person."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "identifier": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "properties": {
+                                "uri": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "format": "uri",
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "legalName": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The legally registered name of the organization."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "scheme": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "id": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ],
+                                                "description": "The identifier of the organization in the selected scheme."
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "milestones": {
+                    "type": "array",
+                    "description": "A list of milestones associated with the tender.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    }
+                },
+                "procurementMethodRationale": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "title": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender title"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "submissionMethod": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "array",
+                                    "null"
+                                ],
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "tenderPeriod": {
+                    "type": "object",
+                    "properties": {
+                        "endDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The end date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "startDate": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "date-time",
+                                        "description": "The start date for the period."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "title": "Period"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "contracts": {
+            "type": "array",
+            "title": "Contracts",
+            "description": "Information from the contract creation phase of the procurement process.",
+            "uniqueItems": true,
+            "items": {
+                "$ref": "#/definitions/Contract"
+            }
+        },
+        "planning": {
+            "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
+            "properties": {
+                "rationale": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "documents": {
+                    "type": "array",
+                    "description": "A list of documents related to the planning process.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }
+                },
+                "budget": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "object",
+                                "title": "Budget Information",
+                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+                                "properties": {
+                                    "source": {
+                                        "format": "uri",
+                                        "title": "Data Source",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "id": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "amount": {
+                                        "$ref": "#/definitions/Value",
+                                        "description": "The value of the budget line item."
+                                    },
+                                    "uri": {
+                                        "format": "uri",
+                                        "title": "Linked budget information",
+                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "description": {
+                                        "title": "Budget Source",
+                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "projectID": {
+                                        "title": "Project Identifier",
+                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    },
+                                    "project": {
+                                        "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "mergeStrategy": "ocdsVersion"
+                                    }
+                                },
+                                "patternProperties": {
+                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "initiationType": {
+            "type": "array",
+            "items": {
+                "properties": {
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Initiation type",
+                        "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
+                        "enum": [
+                            "tender"
+                        ],
+                        "type": "string"
+                    },
+                    "releaseDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "releaseTag": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "buyer": {
+            "title": "Organization",
+            "description": "An organization.",
+            "properties": {
+                "additionalIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                "uniqueItems": true,
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                }
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "address": {
+                    "type": "object",
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                    "properties": {
+                        "postalCode": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The postal code. For example, 94043."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "streetAddress": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "countryName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The country name. For example, United States."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "locality": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The locality. For example, Mountain View."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "region": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The region. For example, CA."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "contactPoint": {
+                    "type": "object",
+                    "description": "An person, contact point or department to contact in relation to this contracting process.",
+                    "properties": {
+                        "telephone": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "email": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The e-mail address of the contact point/person."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "faxNumber": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "url": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A web address for the contact point/person."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "identifier": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "properties": {
+                        "uri": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "legalName": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "scheme": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "name": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "awards": {
+            "type": "array",
+            "title": "Awards",
+            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "uniqueItems": true,
+            "items": {
+                "$ref": "#/definitions/Award"
+            }
+        },
+        "id": {
+            "title": "Release ID",
+            "description": "A unique identifier that identifies this release. A releaseID must be unique within a release-package and must not contain the # character.",
+            "type": "string"
+        },
+        "date": {
+            "title": "Release Date",
+            "format": "date-time",
+            "type": "string",
+            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order."
+        },
         "tag": {
             "title": "Release Tag",
+            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
             "type": "array",
             "items": {
                 "type": "string",
@@ -634,5897 +6516,15 @@
                     "contractTermination",
                     "compiled"
                 ]
-            },
-            "description": "A value from the [releaseTag codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields."
-        },
-        "contracts": {
-            "title": "Contracts",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Contract"
-            },
-            "description": "Information from the contract creation phase of the procurement process.",
-            "uniqueItems": true
-        },
-        "awards": {
-            "title": "Awards",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Award"
-            },
-            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "uniqueItems": true
-        },
-        "initiationType": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseDate": {
-                        "format": "date-time",
-                        "type": "string"
-                    },
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Initiation type",
-                        "type": "string",
-                        "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#initiation-type) codelist. Currently only tender is supported.",
-                        "enum": [
-                            "tender"
-                        ]
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
-                }
             }
         },
-        "language": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseDate": {
-                        "format": "date-time",
-                        "type": "string"
-                    },
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Release language",
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended.",
-                        "default": "en"
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "tender": {
-            "title": "Tender",
-            "properties": {
-                "procuringEntity": {
-                    "title": "Organization",
-                    "properties": {
-                        "contactPoint": {
-                            "properties": {
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "format": "uri",
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        },
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "properties": {
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "format": "uri",
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "properties": {
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An organization.",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "amendment": {
-                    "title": "Amendment information",
-                    "properties": {
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "type": "array",
-                                        "items": {
-                                            "properties": {
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                },
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "description": "Comma-seperated list of affected fields."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "items": {
-                    "title": "Items to be procured",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "value": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#award-criteria)"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#document-type) for details of potential documents to include."
-                },
-                "awardPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "minValue": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "items": {
-                                    "type": "string"
-                                },
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#submission-method)"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "tenderPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "description": "A list of milestones associated with the tender."
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "required": [
-                "id"
-            ]
+        "ocid": {
+            "title": "Open Contracting ID",
+            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)",
+            "type": "string"
         }
     },
-    "type": "object",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Schema for a compiled, versioned Open Contracting Release.",
-    "definitions": {
-        "Implementation": {
-            "title": "Implementation",
-            "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Transaction"
-                    },
-                    "description": "A list of the spending transactions made against this contract",
-                    "uniqueItems": true
-                },
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "description": "As milestones are completed, milestone completions should be documented.",
-                    "uniqueItems": true
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                    "uniqueItems": true
-                }
-            },
-            "type": "object",
-            "description": "Information during the performance / implementation stage of the contract."
-        },
-        "Document": {
-            "title": "Document",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
-                },
-                "datePublished": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "url": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "language": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The document title."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Date that the document was last modified"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "format": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documentType": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A classification of the document described taken from the [documentType codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
-            "required": [
-                "id"
-            ]
-        },
-        "Amendment": {
-            "title": "Amendment information",
-            "properties": {
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Amendment Date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The data of this amendment."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "changes": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Amended fields",
-                                "type": "array",
-                                "items": {
-                                    "properties": {
-                                        "former_value": {
-                                            "type": [
-                                                "string",
-                                                "number",
-                                                "integer",
-                                                "array",
-                                                "object",
-                                                "null"
-                                            ],
-                                            "description": "The previous value of the changed property, in whatever type the property is."
-                                        },
-                                        "property": {
-                                            "type": "string",
-                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "description": "Comma-seperated list of affected fields."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "An explanation for the amendment."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Item": {
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
-                },
-                "quantity": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The number of units required"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "unit": {
-                    "properties": {
-                        "value": {
-                            "properties": {
-                                "currency": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The currency in 3-letter ISO 4217 format."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "amount": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "minimum": 0,
-                                                "type": [
-                                                    "number",
-                                                    "null"
-                                                ],
-                                                "description": "Amount as a number."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Name of the unit"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit.",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "additionalClassifications": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Classification"
-                                },
-                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
-                                "uniqueItems": true
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the goods, services to be provided."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "classification": {
-                    "properties": {
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The classification code drawn from the selected scheme."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "description": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A textual description or title for the code."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#item-classification-scheme) wherever possible."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "A good, service, or work to be contracted.",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Classification": {
-            "properties": {
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The classification code drawn from the selected scheme."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A textual description or title for the code."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "scheme": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#item-classification-scheme) wherever possible."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Transaction": {
-            "title": "Transaction Information",
-            "properties": {
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date of the transaction"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
-                },
-                "source": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Data Source",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Linked spending information",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI pointing directly to a machine-readable record about this spending transaction."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amount": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "receiverOrganization": {
-                    "properties": {
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "providerOrganization": {
-                    "properties": {
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data.",
-            "required": [
-                "id"
-            ]
-        },
-        "Identifier": {
-            "properties": {
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The identifier of the organization in the selected scheme."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "legalName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The legally registered name of the organization."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "scheme": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Tender": {
-            "title": "Tender",
-            "properties": {
-                "procuringEntity": {
-                    "title": "Organization",
-                    "properties": {
-                        "contactPoint": {
-                            "properties": {
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "format": "uri",
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        },
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "properties": {
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "format": "uri",
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "properties": {
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseDate": {
-                                                "format": "date-time",
-                                                "type": "string"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An organization.",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "amendment": {
-                    "title": "Amendment information",
-                    "properties": {
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "type": "array",
-                                        "items": {
-                                            "properties": {
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                },
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "description": "Comma-seperated list of affected fields."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "items": {
-                    "title": "Items to be procured",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "value": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#award-criteria)"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#document-type) for details of potential documents to include."
-                },
-                "awardPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "minValue": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "items": {
-                                    "type": "string"
-                                },
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#submission-method)"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "tenderPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "description": "A list of milestones associated with the tender."
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "required": [
-                "id"
-            ]
-        },
-        "Award": {
-            "title": "Award",
-            "properties": {
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award Status",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The current status of the award drawn from the [awardStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#award-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "title": "Award ID",
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/) for further details."
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date of the contract award. This is usually the date on which a decision to award was made."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
-                    "uniqueItems": true,
-                    "title": "Items Awarded",
-                    "type": "array",
-                    "minItems": 1
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award title"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "title": "Amendment information",
-                    "properties": {
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "type": "array",
-                                        "items": {
-                                            "properties": {
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                },
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "description": "Comma-seperated list of affected fields."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the award, including any notices.",
-                    "uniqueItems": true
-                },
-                "suppliers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks.",
-                                "uniqueItems": true
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award description"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "value": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "contractPeriod": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "required": [
-                "id"
-            ]
-        },
-        "Organization": {
-            "title": "Organization",
-            "properties": {
-                "contactPoint": {
-                    "properties": {
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                },
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/#organization-identifiers). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "identifier": {
-                    "properties": {
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "address": {
-                    "properties": {
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "region": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "An organization.",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Budget": {
-            "mergeStrategy": "ocdsVersion",
-            "title": "Budget Information",
-            "properties": {
-                "id": {
-                    "mergeStrategy": "ocdsVersion",
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ],
-                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
-                },
-                "source": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Data Source",
-                    "format": "uri",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                },
-                "uri": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Linked budget information",
-                    "format": "uri",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process."
-                },
-                "amount": {
-                    "description": "The value of the budget line item.",
-                    "$ref": "#/definitions/Value"
-                },
-                "projectID": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Project Identifier",
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ],
-                    "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects."
-                },
-                "description": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Budget Source",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project."
-                },
-                "project": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Project Title",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above."
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information."
-        },
-        "ContactPoint": {
-            "properties": {
-                "faxNumber": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "email": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The e-mail address of the contact point/person."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "url": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A web address for the contact point/person."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "telephone": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "An person, contact point or department to contact in relation to this contracting process.",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Planning": {
-            "title": "Planning",
-            "properties": {
-                "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "A list of documents related to the planning process."
-                },
-                "budget": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Budget Information",
-                                "properties": {
-                                    "id": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
-                                    },
-                                    "source": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Data Source",
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                                    },
-                                    "uri": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Linked budget information",
-                                        "format": "uri",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process."
-                                    },
-                                    "amount": {
-                                        "description": "The value of the budget line item.",
-                                        "$ref": "#/definitions/Value"
-                                    },
-                                    "projectID": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Project Identifier",
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects."
-                                    },
-                                    "description": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Budget Source",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project."
-                                    },
-                                    "project": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Project Title",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above."
-                                    }
-                                },
-                                "type": "object",
-                                "patternProperties": {
-                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                },
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
-            "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Contract": {
-            "title": "Contract",
-            "properties": {
-                "dateSigned": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
-                    "uniqueItems": true,
-                    "title": "Items Contracted",
-                    "type": "array",
-                    "minItems": 1
-                },
-                "period": {
-                    "title": "Period",
-                    "properties": {
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract title"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "implementation": {
-                    "title": "Implementation",
-                    "properties": {
-                        "transactions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Transaction"
-                            },
-                            "description": "A list of the spending transactions made against this contract",
-                            "uniqueItems": true
-                        },
-                        "milestones": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Milestone"
-                            },
-                            "description": "As milestones are completed, milestone completions should be documented.",
-                            "uniqueItems": true
-                        },
-                        "documents": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Document"
-                            },
-                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                            "uniqueItems": true
-                        }
-                    },
-                    "type": "object",
-                    "description": "Information during the performance / implementation stage of the contract."
-                },
-                "amendment": {
-                    "title": "Amendment information",
-                    "properties": {
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "type": "array",
-                                        "items": {
-                                            "properties": {
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                },
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "description": "Comma-seperated list of affected fields."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "value": {
-                    "properties": {
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseDate": {
-                                        "format": "date-time",
-                                        "type": "string"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object"
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract description"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Contract Status",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists/#contract-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "terminated"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "title": "Contract ID",
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://ocds.open-contracting.org/standard/r/1__0__0/en/key_concepts/identifiers/) for further details."
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the contract, including any notices.",
-                    "uniqueItems": true
-                },
-                "awardID": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award ID",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "description": "The award.id against which this contract is being issued."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Information regarding the signed contract between the buyer and supplier(s).",
-            "required": [
-                "id",
-                "awardID"
-            ]
-        },
-        "Address": {
-            "properties": {
-                "countryName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The country name. For example, United States."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "locality": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The locality. For example, Mountain View."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "streetAddress": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "postalCode": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The postal code. For example, 94043."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "region": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The region. For example, CA."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-            "patternProperties": {
-                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Milestone": {
-            "properties": {
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://ocds.open-contracting.org/standard/r/1__0__0/en/schema/codelists#milestone-status).",
-                                "enum": [
-                                    "met",
-                                    "notMet",
-                                    "partiallyMet",
-                                    null
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
-                },
-                "dueDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the milestone is due."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Milestone title"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the milestone."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "List of documents associated with this milestone.",
-                    "uniqueItems": true
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Value": {
-            "properties": {
-                "currency": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The currency in 3-letter ISO 4217 format."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amount": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "number",
-                                    "null"
-                                ],
-                                "description": "Amount as a number."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object"
-        },
-        "Period": {
-            "title": "Period",
-            "properties": {
-                "startDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The start date for the period."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "endDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The end date for the period."
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object"
-        }
-    },
     "required": [
         "ocid",
         "id",

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -371,7 +371,7 @@
                                             "string",
                                             "null"
                                         ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                     },
                                     "releaseDate": {
                                         "type": "string",
@@ -482,7 +482,7 @@
                                             "string",
                                             "null"
                                         ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                     },
                                     "releaseDate": {
                                         "type": "string",
@@ -763,7 +763,7 @@
                             },
                             "value": {
                                 "title": "Contract Status",
-                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#contract-status)",
+                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
                                 "enum": [
                                     "pending",
                                     "active",
@@ -1379,7 +1379,7 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                             },
                             "releaseDate": {
                                 "type": "string",
@@ -1866,7 +1866,7 @@
                                             "string",
                                             "null"
                                         ],
-                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible."
+                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
                                     },
                                     "releaseDate": {
                                         "type": "string",
@@ -2250,7 +2250,7 @@
                             },
                             "value": {
                                 "title": "Award Status",
-                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists//#award-status)",
+                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
                                 "enum": [
                                     "pending",
                                     "active",
@@ -2692,7 +2692,7 @@
                                     "string",
                                     "null"
                                 ],
-                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#item-classification-scheme) wherever possible."
+                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
                             },
                             "releaseDate": {
                                 "type": "string",
@@ -3101,7 +3101,7 @@
                                             "string",
                                             "null"
                                         ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                     },
                                     "releaseDate": {
                                         "type": "string",
@@ -4346,7 +4346,7 @@
                                                     "string",
                                                     "null"
                                                 ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                             },
                                             "releaseDate": {
                                                 "type": "string",
@@ -5627,7 +5627,7 @@
                                                     "string",
                                                     "null"
                                                 ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                             },
                                             "releaseDate": {
                                                 "type": "string",
@@ -6399,7 +6399,7 @@
                                             "string",
                                             "null"
                                         ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists//#organization-identifier-scheme)."
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
                                     },
                                     "releaseDate": {
                                         "type": "string",


### PR DESCRIPTION
I've updated the links to documentation in the schema to point to the new docs.

I've not updated the internal links between schema (E.g. links to http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json in `record-package-schema.json`).

Not sure if these need to be updated or not at this point, and if so, any considerations we should have for making those updates. 
