### PR TITLE
[#285] Update the versioned schema to fix the versioning of lists

### DIFF
--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -1,28 +1,159 @@
 #!/usr/bin/env python
-import jsonmerge
 import json
+from collections import OrderedDict
+import copy
+
+version_template = OrderedDict({
+    "type": "array",
+    "items": {
+        "properties": {
+            "releaseDate": {
+                "format": "date-time",
+                "type": "string"
+            },
+            "releaseID": {
+                "type": "string"
+            },
+            "value": {
+            },
+            "releaseTag": {
+                "type": "array",
+                "items": {"type": "string"}
+            }
+        }
+   }
+})
+
+def add_versions(schema, location=''):
+    for key, value in list(schema['properties'].items()):
+        prop_type = value.get('type')
+        value.pop("title", None)
+        value.pop("description", None)
+        value.pop("mergeStrategy", None)
+        value.pop("mergeOptions", None)
+        if not prop_type:
+            continue
+        if key == 'id':
+            if location not in ("Budget", "Tender", "Classification", "Identifier"):
+                continue
+        if prop_type == ["string", "null"] and "enum" not in value:
+            new_value = {}
+            format = value.get('format')
+            if format == 'uri':
+                new_value["$ref"] = "#/definitions/StringNullUriVersioned"
+            elif format == 'date-time':
+                new_value["$ref"] = "#/definitions/StringNullDateTimeVersioned"
+            else:
+                new_value["$ref"] = "#/definitions/StringNullVersioned"
+            schema['properties'][key] = new_value
+        elif prop_type == "array":
+            version = copy.deepcopy(version_template)
+            version_properties = version["items"]["properties"]
+            if key in ('tenderers', 'suppliers'):
+                version_properties["value"] = {"type": "array",
+                                               "items": {"$ref": "#/definitions/OrganizationUnversioned"},
+                                               "uniqueItems": True}
+                schema['properties'][key] = version
+            if key == 'additionalIdentifiers':
+                version_properties["value"] = {"type": "array",
+                                               "items": {"$ref": "#/definitions/IdentifierUnversioned"},
+                                               "uniqueItems": True}
+                schema['properties'][key] = version
+            if key == 'additionalClassifications':
+                version_properties["value"] = {"type": "array",
+                                               "items": {"$ref": "#/definitions/ClassificationUnversioned"},
+                                               "uniqueItems": True}
+                schema['properties'][key] = version
+            if key == 'changes':
+                version_properties["value"] = {"type": "array",
+                                               "items": value["items"]}
+                schema['properties'][key] = version
+            
+        elif prop_type == "object":
+            add_versions(value, key)
+        else:
+            version = copy.deepcopy(version_template)
+            version_properties = version["items"]["properties"]
+            version_properties["value"] = value
+            schema['properties'][key] = version
+
+
+    for key, value in schema.get('definitions', {}).items():
+        add_versions(value, key)
+
+            
+def add_string_definitions(schema):
+    for item, format in {"StringNullUriVersioned": "uri", 
+                         "StringNullDateTimeVersioned": "date-time",
+                         "StringNullVersioned": None}.items():
+        version = copy.deepcopy(version_template)
+        version_properties = version["items"]["properties"]
+        version_properties["value"] = {"type": ["string", "null"]}
+        if format:
+            version_properties["value"]["format"] = format
+        schema['definitions'][item] = version
 
 
 def get_versioned_validation_schema(versioned_release):
-    merger = jsonmerge.Merger(versioned_release)
 
-    versioned_validation_schema = merger.get_schema()
-    versioned_validation_schema["id"] = "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json"  # nopep8
-    versioned_validation_schema["$schema"] = "http://json-schema.org/draft-04/schema#"  # nopep8
-    versioned_validation_schema["title"] = "Schema for a compiled, versioned Open Contracting Release."  # nopep8
+    versioned_release.pop("id", None)
+    versioned_release["$schema"] = "http://json-schema.org/draft-04/schema#"  # nopep8
+    versioned_release["title"] = "Schema for a compiled, versioned Open Contracting Release."  # nopep8
 
-    return versioned_validation_schema
+    definitions = versioned_release['definitions']
+    for key, value in definitions.items():
+        value.pop("title", None)
+        value.pop("description", None)
+        for prop_value in value['properties'].values():
+            prop_value.pop("mergeStrategy", None)
+            prop_value.pop("mergeOptions", None)
+            prop_value.pop("title", None)
+            prop_value.pop("description", None)
+
+
+    OrganizationUnversioned = copy.deepcopy(definitions['Organization'])
+    IdentifierUnversioned = copy.deepcopy(definitions['Identifier'])
+    ClassificationUnversioned = copy.deepcopy(definitions['Classification'])
+    AddressUnversioned = copy.deepcopy(definitions['Address'])
+    ContactPointUnversioned = copy.deepcopy(definitions['ContactPoint'])
+
+    ocid = versioned_release['properties'].pop("ocid")
+    versioned_release['properties'].pop("date")
+    versioned_release['properties'].pop("id")
+    versioned_release['properties'].pop("tag")
+
+    versioned_release['required'] = [
+        "ocid",
+        "initiationType"
+    ]
+
+    #types_count = Counter()
+    #get_types(versioned_release, types_count)
+    add_versions(versioned_release)
+
+    versioned_release['properties']["ocid"] = ocid
+    definitions['IdentifierUnversioned'] = IdentifierUnversioned
+    definitions['ClassificationUnversioned'] = ClassificationUnversioned
+    definitions['AddressUnversioned'] = AddressUnversioned
+    definitions['ContactPointUnversioned'] = ContactPointUnversioned
+    OrganizationUnversioned["properties"]["identifier"]["$ref"] = "#/definitions/IdentifierUnversioned"
+    OrganizationUnversioned["properties"]["additionalIdentifiers"]["items"]["$ref"] = "#/definitions/IdentifierUnversioned"
+    OrganizationUnversioned["properties"]["address"]["$ref"] = "#/definitions/AddressUnversioned"
+    OrganizationUnversioned["properties"]["contactPoint"]["$ref"] = "#/definitions/ContactPointUnversioned"
+    definitions['OrganizationUnversioned'] = OrganizationUnversioned
+    add_string_definitions(versioned_release)
+
+    return versioned_release
 
 
 if __name__ == "__main__":
     from os.path import abspath, dirname, join
-
     schema_dir = dirname(dirname(abspath(__file__)))
 
     with open(join(schema_dir, 'release-schema.json'), 'r') as f:
-        vr = json.loads(f.read())
+        release_schema = json.loads(f.read(), object_pairs_hook=OrderedDict)
 
-    new_validation_schema = get_versioned_validation_schema(vr)
+    new_validation_schema = get_versioned_validation_schema(release_schema)
 
     with open(join(schema_dir, 'versioned-release-validation-schema.json'), 'w') as f:
         f.write(json.dumps(new_validation_schema, indent=4))

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -1,6535 +1,1626 @@
 {
-    "type": "object",
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
-    "title": "Schema for a compiled, versioned Open Contracting Release.",
-    "definitions": {
-        "Value": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "number",
-                                    "null"
-                                ],
-                                "description": "Amount as a number."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "currency": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The currency in 3-letter ISO 4217 format."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
+    "$schema": "http://json-schema.org/draft-04/schema#", 
+    "title": "Schema for a compiled, versioned Open Contracting Release.", 
+    "type": "object", 
+    "properties": {
+        "initiationType": {
+            "items": {
+                "properties": {
+                    "releaseDate": {
+                        "type": "string", 
+                        "format": "date-time"
+                    }, 
+                    "releaseID": {
+                        "type": "string"
+                    }, 
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "value": {
+                        "type": "string", 
+                        "enum": [
+                            "tender"
+                        ]
                     }
                 }
-            }
-        },
+            }, 
+            "type": "array"
+        }, 
+        "planning": {
+            "$ref": "#/definitions/Planning"
+        }, 
+        "tender": {
+            "$ref": "#/definitions/Tender"
+        }, 
+        "buyer": {
+            "$ref": "#/definitions/Organization"
+        }, 
+        "awards": {
+            "type": "array", 
+            "items": {
+                "$ref": "#/definitions/Award"
+            }, 
+            "uniqueItems": true
+        }, 
+        "contracts": {
+            "type": "array", 
+            "items": {
+                "$ref": "#/definitions/Contract"
+            }, 
+            "uniqueItems": true
+        }, 
+        "language": {
+            "$ref": "#/definitions/StringNullVersioned"
+        }, 
+        "ocid": {
+            "title": "Open Contracting ID", 
+            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)", 
+            "type": "string", 
+            "mergeStrategy": "ocdsOmit"
+        }
+    }, 
+    "required": [
+        "ocid", 
+        "initiationType"
+    ], 
+    "definitions": {
         "Planning": {
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
+            "type": "object", 
             "properties": {
+                "budget": {
+                    "$ref": "#/definitions/Budget"
+                }, 
                 "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "documents": {
-                    "type": "array",
-                    "description": "A list of documents related to the planning process.",
+                    "type": "array", 
                     "items": {
                         "$ref": "#/definitions/Document"
                     }
-                },
-                "budget": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "object",
-                                "title": "Budget Information",
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-                                "properties": {
-                                    "source": {
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
-                                    },
-                                    "uri": {
-                                        "format": "uri",
-                                        "title": "Linked budget information",
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "description": {
-                                        "title": "Budget Source",
-                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "projectID": {
-                                        "title": "Project Identifier",
-                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "project": {
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    }
-                                },
-                                "patternProperties": {
-                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
                 }
-            },
-            "type": "object",
+            }, 
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
             }
-        },
-        "Transaction": {
-            "type": "object",
-            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data.",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
-                },
-                "amount": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Linked spending information",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI pointing directly to a machine-readable record about this spending transaction."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "providerOrganization": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "receiverOrganization": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date of the transaction"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "source": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Data Source",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "title": "Transaction Information",
+        }, 
+        "Tender": {
+            "type": "object", 
             "required": [
                 "id"
-            ]
-        },
-        "Contract": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Contract",
-            "description": "Information regarding the signed contract between the buyer and supplier(s).",
+            ], 
             "properties": {
-                "period": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the contract, including any notices.",
-                    "uniqueItems": true
-                },
                 "id": {
-                    "title": "Contract ID",
-                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
-                    "type": [
-                        "string",
-                        "integer"
-                    ]
-                },
-                "implementation": {
-                    "type": "object",
-                    "description": "Information during the performance / implementation stage of the contract.",
-                    "properties": {
-                        "milestones": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Milestone"
-                            },
-                            "description": "As milestones are completed, milestone completions should be documented.",
-                            "uniqueItems": true
-                        },
-                        "transactions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Transaction"
-                            },
-                            "description": "A list of the spending transactions made against this contract",
-                            "uniqueItems": true
-                        },
-                        "documents": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Document"
-                            },
-                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                            "uniqueItems": true
-                        }
-                    },
-                    "title": "Implementation"
-                },
-                "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Contract Status",
-                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "terminated"
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
-                                "type": "string",
+                                "type": "string", 
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardID": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
+                            }, 
                             "releaseID": {
                                 "type": "string"
-                            },
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
                             "value": {
-                                "title": "Award ID",
-                                "description": "The award.id against which this contract is being issued.",
                                 "type": [
-                                    "string",
+                                    "string", 
                                     "integer"
                                 ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
                             }
                         }
-                    }
-                },
-                "dateSigned": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    }, 
+                    "type": "array"
+                }, 
                 "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "description": {
-                    "type": "array",
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "status": {
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
                             "releaseID": {
                                 "type": "string"
-                            },
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
                             "value": {
                                 "type": [
-                                    "string",
+                                    "string", 
                                     "null"
-                                ],
-                                "description": "Contract description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
+                                ], 
+                                "enum": [
+                                    "planned", 
+                                    "active", 
+                                    "cancelled", 
+                                    "unsuccessful", 
+                                    "complete", 
+                                    null
+                                ]
                             }
                         }
-                    }
-                },
+                    }, 
+                    "type": "array"
+                }, 
                 "items": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "minItems": 1,
-                    "title": "Items Contracted",
-                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
+                    "type": "array", 
                     "items": {
                         "$ref": "#/definitions/Item"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "minValue": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "value": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "procurementMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ], 
+                                "enum": [
+                                    "open", 
+                                    "selective", 
+                                    "limited", 
+                                    null
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "procurementMethodRationale": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "awardCriteria": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "awardCriteriaDetails": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "submissionMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "array", 
+                                    "null"
+                                ], 
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "submissionMethodDetails": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "tenderPeriod": {
+                    "$ref": "#/definitions/Period"
+                }, 
+                "enquiryPeriod": {
+                    "$ref": "#/definitions/Period"
+                }, 
+                "hasEnquiries": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "boolean", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "eligibilityCriteria": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "awardPeriod": {
+                    "$ref": "#/definitions/Period"
+                }, 
+                "numberOfTenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "definition": "The number of entities who submit a tender.", 
+                                "type": [
+                                    "integer", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "tenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "uniqueItems": true, 
+                                "items": {
+                                    "$ref": "#/definitions/OrganizationUnversioned"
+                                }, 
+                                "type": "array"
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "procuringEntity": {
+                    "$ref": "#/definitions/Organization"
+                }, 
+                "documents": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Document"
                     }
-                },
+                }, 
+                "milestones": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    }
+                }, 
                 "amendment": {
-                    "type": "object",
+                    "$ref": "#/definitions/Amendment"
+                }
+            }, 
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Award": {
+            "type": "object", 
+            "required": [
+                "id"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "title": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ], 
+                                "enum": [
+                                    "pending", 
+                                    "active", 
+                                    "cancelled", 
+                                    "unsuccessful"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "date": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "value": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "suppliers": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "uniqueItems": true, 
+                                "items": {
+                                    "$ref": "#/definitions/OrganizationUnversioned"
+                                }, 
+                                "type": "array"
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "items": {
+                    "type": "array", 
+                    "minItems": 1, 
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "contractPeriod": {
+                    "$ref": "#/definitions/Period"
+                }, 
+                "documents": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "amendment": {
+                    "$ref": "#/definitions/Amendment"
+                }
+            }, 
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Contract": {
+            "type": "object", 
+            "required": [
+                "id", 
+                "awardID"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "awardID": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "integer"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "title": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ], 
+                                "enum": [
+                                    "pending", 
+                                    "active", 
+                                    "cancelled", 
+                                    "terminated"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "period": {
+                    "$ref": "#/definitions/Period"
+                }, 
+                "value": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "items": {
+                    "type": "array", 
+                    "minItems": 1, 
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "dateSigned": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "documents": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "amendment": {
+                    "$ref": "#/definitions/Amendment"
+                }, 
+                "implementation": {
+                    "$ref": "#/definitions/Implementation"
+                }
+            }, 
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Implementation": {
+            "type": "object", 
+            "properties": {
+                "transactions": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Transaction"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "milestones": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "documents": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }, 
+                    "uniqueItems": true
+                }
+            }
+        }, 
+        "Milestone": {
+            "type": "object", 
+            "required": [
+                "id"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "title": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "dueDate": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "dateModified": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ], 
+                                "enum": [
+                                    "met", 
+                                    "notMet", 
+                                    "partiallyMet", 
+                                    null
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "documents": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    }, 
+                    "uniqueItems": true
+                }
+            }, 
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Document": {
+            "type": "object", 
+            "required": [
+                "id"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "documentType": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "title": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "url": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }, 
+                "datePublished": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "dateModified": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "format": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "language": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }
+            }, 
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Budget": {
+            "type": "object", 
+            "mergeStrategy": "ocdsVersion", 
+            "properties": {
+                "source": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }, 
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "integer", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "amount": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "project": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "projectID": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "integer", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "uri": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }
+            }, 
+            "patternProperties": {
+                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Transaction": {
+            "type": "object", 
+            "required": [
+                "id"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "source": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }, 
+                "date": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "amount": {
+                    "$ref": "#/definitions/Value"
+                }, 
+                "providerOrganization": {
+                    "$ref": "#/definitions/Identifier"
+                }, 
+                "receiverOrganization": {
+                    "$ref": "#/definitions/Identifier"
+                }, 
+                "uri": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }
+            }
+        }, 
+        "Organization": {
+            "type": "object", 
+            "properties": {
+                "identifier": {
+                    "$ref": "#/definitions/Identifier"
+                }, 
+                "additionalIdentifiers": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "uniqueItems": true, 
+                                "items": {
+                                    "$ref": "#/definitions/IdentifierUnversioned"
+                                }, 
+                                "type": "array"
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "name": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "address": {
+                    "$ref": "#/definitions/Address"
+                }, 
+                "contactPoint": {
+                    "$ref": "#/definitions/ContactPoint"
+                }
+            }, 
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
+        "Item": {
+            "type": "object", 
+            "required": [
+                "id"
+            ], 
+            "properties": {
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer"
+                    ]
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "classification": {
+                    "$ref": "#/definitions/Classification"
+                }, 
+                "additionalClassifications": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "uniqueItems": true, 
+                                "items": {
+                                    "$ref": "#/definitions/ClassificationUnversioned"
+                                }, 
+                                "type": "array"
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "quantity": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "minimum": 0, 
+                                "type": [
+                                    "integer", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "unit": {
+                    "type": "object", 
+                    "properties": {
+                        "name": {
+                            "$ref": "#/definitions/StringNullVersioned"
+                        }, 
+                        "value": {
+                            "$ref": "#/definitions/Value"
+                        }
+                    }, 
                     "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                             "type": [
-                                "string",
+                                "string", 
                                 "null"
                             ]
                         }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
+                    }
                 }
-            },
-            "required": [
-                "id",
-                "awardID"
-            ]
-        },
-        "Implementation": {
-            "type": "object",
-            "description": "Information during the performance / implementation stage of the contract.",
-            "properties": {
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "description": "As milestones are completed, milestone completions should be documented.",
-                    "uniqueItems": true
-                },
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Transaction"
-                    },
-                    "description": "A list of the spending transactions made against this contract",
-                    "uniqueItems": true
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                    "uniqueItems": true
-                }
-            },
-            "title": "Implementation"
-        },
-        "Milestone": {
-            "type": "object",
+            }, 
             "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
-            },
-            "properties": {
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status).",
-                                "enum": [
-                                    "met",
-                                    "notMet",
-                                    "partiallyMet",
-                                    null
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dueDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date the milestone is due."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "List of documents associated with this milestone.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Milestone title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the milestone."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
+            }
+        }, 
         "Amendment": {
-            "type": "object",
+            "type": "object", 
+            "properties": {
+                "date": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "changes": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "items": {
+                                    "type": "object", 
+                                    "properties": {
+                                        "property": {
+                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ", 
+                                            "type": "string"
+                                        }, 
+                                        "former_value": {
+                                            "description": "The previous value of the changed property, in whatever type the property is.", 
+                                            "type": [
+                                                "string", 
+                                                "number", 
+                                                "integer", 
+                                                "array", 
+                                                "object", 
+                                                "null"
+                                            ]
+                                        }
+                                    }
+                                }, 
+                                "type": "array"
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "rationale": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }
+            }, 
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
-            },
+            }
+        }, 
+        "Classification": {
+            "type": "object", 
             "properties": {
-                "changes": {
-                    "type": "array",
+                "scheme": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "id": {
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "title": "Amended fields",
-                                "description": "Comma-seperated list of affected fields.",
-                                "type": "array",
+                            }, 
+                            "releaseTag": {
                                 "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "property": {
-                                            "type": "string",
-                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                        },
-                                        "former_value": {
-                                            "type": [
-                                                "string",
-                                                "number",
-                                                "integer",
-                                                "array",
-                                                "object",
-                                                "null"
-                                            ],
-                                            "description": "The previous value of the changed property, in whatever type the property is."
-                                        }
-                                    }
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
                             "value": {
                                 "type": [
-                                    "string",
+                                    "string", 
+                                    "integer", 
                                     "null"
-                                ],
-                                "description": "An explanation for the amendment."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
+                                ]
                             }
                         }
-                    }
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Amendment Date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The data of this amendment."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    }, 
+                    "type": "array"
+                }, 
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "uri": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
                 }
-            },
-            "title": "Amendment information"
-        },
+            }, 
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
+            }
+        }, 
         "Identifier": {
-            "type": "object",
+            "type": "object", 
+            "properties": {
+                "scheme": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseDate": {
+                                "type": "string", 
+                                "format": "date-time"
+                            }, 
+                            "releaseID": {
+                                "type": "string"
+                            }, 
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "string", 
+                                    "integer", 
+                                    "null"
+                                ]
+                            }
+                        }
+                    }, 
+                    "type": "array"
+                }, 
+                "legalName": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "uri": {
+                    "$ref": "#/definitions/StringNullUriVersioned"
+                }
+            }, 
             "patternProperties": {
                 "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
-            },
-            "properties": {
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "legalName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The legally registered name of the organization."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "scheme": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The identifier of the organization in the selected scheme."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
             }
-        },
+        }, 
         "Address": {
-            "type": "object",
-            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+            "type": "object", 
             "properties": {
-                "postalCode": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The postal code. For example, 94043."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
                 "streetAddress": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "countryName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The country name. For example, United States."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "locality": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The locality. For example, Mountain View."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "region": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The region. For example, CA."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "postalCode": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "countryName": {
+                    "$ref": "#/definitions/StringNullVersioned"
                 }
-            },
+            }, 
             "patternProperties": {
                 "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
             }
-        },
-        "Budget": {
-            "type": "object",
-            "mergeStrategy": "ocdsVersion",
-            "title": "Budget Information",
-            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-            "properties": {
-                "source": {
-                    "format": "uri",
-                    "title": "Data Source",
-                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ],
-                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                    "mergeStrategy": "ocdsVersion"
-                },
-                "amount": {
-                    "$ref": "#/definitions/Value",
-                    "description": "The value of the budget line item."
-                },
-                "uri": {
-                    "format": "uri",
-                    "title": "Linked budget information",
-                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                },
-                "description": {
-                    "title": "Budget Source",
-                    "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                },
-                "projectID": {
-                    "title": "Project Identifier",
-                    "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                },
-                "project": {
-                    "title": "Project Title",
-                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Item": {
-            "type": "object",
-            "description": "A good, service, or work to be contracted.",
-            "properties": {
-                "additionalClassifications": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Classification"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "unit": {
-                    "type": "object",
-                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit.",
-                    "properties": {
-                        "value": {
-                            "type": "object",
-                            "properties": {
-                                "amount": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "minimum": 0,
-                                                "type": [
-                                                    "number",
-                                                    "null"
-                                                ],
-                                                "description": "Amount as a number."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "currency": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The currency in 3-letter ISO 4217 format."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Name of the unit"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "quantity": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The number of units required"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
-                },
-                "classification": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "description": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A textual description or title for the code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The classification code drawn from the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the goods, services to be provided."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "required": [
-                "id"
-            ],
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Document": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Document",
-            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
-            "properties": {
-                "url": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "language": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "format": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documentType": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The document title."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "Date that the document was last modified"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "datePublished": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Award": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Award",
-            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "properties": {
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award Status",
-                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful"
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the award, including any notices.",
-                    "uniqueItems": true
-                },
-                "id": {
-                    "title": "Award ID",
-                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
-                    "type": [
-                        "string",
-                        "integer"
-                    ]
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "suppliers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date of the contract award. This is usually the date on which a decision to award was made."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "minItems": 1,
-                    "title": "Items Awarded",
-                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "contractPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Period": {
-            "type": "object",
-            "properties": {
-                "endDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The end date for the period."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "startDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The start date for the period."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "title": "Period"
-        },
-        "Classification": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "properties": {
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A textual description or title for the code."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "scheme": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The classification code drawn from the selected scheme."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "Organization": {
-            "title": "Organization",
-            "description": "An organization.",
-            "properties": {
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "address": {
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                    "properties": {
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "region": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "contactPoint": {
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "properties": {
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "identifier": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
+        }, 
         "ContactPoint": {
-            "type": "object",
-            "description": "An person, contact point or department to contact in relation to this contracting process.",
+            "type": "object", 
             "properties": {
-                "telephone": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                "name": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "email": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The e-mail address of the contact point/person."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
+                "telephone": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "faxNumber": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
+                    "$ref": "#/definitions/StringNullVersioned"
+                }, 
                 "url": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": "A web address for the contact point/person."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    "$ref": "#/definitions/StringNullUriVersioned"
                 }
-            },
+            }, 
             "patternProperties": {
                 "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
             }
-        },
-        "Tender": {
-            "type": "object",
-            "patternProperties": {
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Tender",
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
+        }, 
+        "Value": {
+            "type": "object", 
             "properties": {
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": "array",
+                "amount": {
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
-                            },
                             "releaseDate": {
-                                "type": "string",
+                                "type": "string", 
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
+                            }, 
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
+                            }, 
                             "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "title": "Items to be procured",
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "minValue": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procuringEntity": {
-                    "title": "Organization",
-                    "description": "An organization.",
-                    "properties": {
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true,
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "properties": {
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "properties": {
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "properties": {
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender.",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    }
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
                                 "items": {
                                     "type": "string"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
+                                }, 
+                                "type": "array"
+                            }, 
+                            "value": {
+                                "type": [
+                                    "number", 
+                                    "null"
+                                ], 
+                                "minimum": 0
                             }
                         }
-                    }
-                },
-                "tenderPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        }
-    },
-    "properties": {
-        "language": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Release language",
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended.",
-                        "default": "en"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
+                    }, 
+                    "type": "array"
+                }, 
+                "currency": {
+                    "$ref": "#/definitions/StringNullVersioned"
                 }
             }
-        },
-        "tender": {
-            "type": "object",
+        }, 
+        "Period": {
+            "type": "object", 
+            "properties": {
+                "startDate": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }, 
+                "endDate": {
+                    "$ref": "#/definitions/StringNullDateTimeVersioned"
+                }
+            }
+        }, 
+        "IdentifierUnversioned": {
+            "type": "object", 
+            "properties": {
+                "scheme": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "id": {
+                    "type": [
+                        "string", 
+                        "integer", 
+                        "null"
+                    ]
+                }, 
+                "legalName": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "uri": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ], 
+                    "format": "uri"
+                }
+            }, 
             "patternProperties": {
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                }
+            }
+        }, 
+        "ClassificationUnversioned": {
+            "type": "object", 
+            "properties": {
+                "scheme": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                }, 
+                "id": {
                     "type": [
-                        "string",
+                        "string", 
+                        "integer", 
                         "null"
                     ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                }, 
+                "description": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
-                },
+                }, 
+                "uri": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ], 
+                    "format": "uri"
+                }
+            }, 
+            "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
-            },
-            "title": "Tender",
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "properties": {
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "title": "Items to be procured",
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "minValue": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procuringEntity": {
-                    "title": "Organization",
-                    "description": "An organization.",
-                    "properties": {
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true,
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "properties": {
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "properties": {
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "properties": {
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender.",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    }
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "contracts": {
-            "type": "array",
-            "title": "Contracts",
-            "description": "Information from the contract creation phase of the procurement process.",
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/Contract"
             }
-        },
-        "planning": {
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
+        }, 
+        "AddressUnversioned": {
+            "type": "object", 
             "properties": {
-                "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "A list of documents related to the planning process.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "budget": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "object",
-                                "title": "Budget Information",
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-                                "properties": {
-                                    "source": {
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
-                                    },
-                                    "uri": {
-                                        "format": "uri",
-                                        "title": "Linked budget information",
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "description": {
-                                        "title": "Budget Source",
-                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "projectID": {
-                                        "title": "Project Identifier",
-                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "project": {
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    }
-                                },
-                                "patternProperties": {
-                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                "streetAddress": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "locality": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "region": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "postalCode": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "countryName": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
                 }
-            },
-            "type": "object",
+            }, 
             "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
             }
-        },
-        "initiationType": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Initiation type",
-                        "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
-                        "enum": [
-                            "tender"
-                        ],
-                        "type": "string"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "buyer": {
-            "title": "Organization",
-            "description": "An organization.",
+        }, 
+        "ContactPointUnversioned": {
+            "type": "object", 
             "properties": {
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "address": {
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                    "properties": {
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "region": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "contactPoint": {
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "properties": {
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "identifier": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
                 "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "email": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "telephone": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "faxNumber": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "url": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ], 
+                    "format": "uri"
                 }
-            },
-            "type": "object",
+            }, 
             "patternProperties": {
                 "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
-                        "string",
+                        "string", 
                         "null"
                     ]
                 }
             }
-        },
-        "awards": {
-            "type": "array",
-            "title": "Awards",
-            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/Award"
+        }, 
+        "OrganizationUnversioned": {
+            "type": "object", 
+            "properties": {
+                "identifier": {
+                    "$ref": "#/definitions/IdentifierUnversioned"
+                }, 
+                "additionalIdentifiers": {
+                    "type": "array", 
+                    "items": {
+                        "$ref": "#/definitions/IdentifierUnversioned"
+                    }, 
+                    "uniqueItems": true
+                }, 
+                "name": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }, 
+                "address": {
+                    "$ref": "#/definitions/AddressUnversioned"
+                }, 
+                "contactPoint": {
+                    "$ref": "#/definitions/ContactPointUnversioned"
+                }
+            }, 
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string", 
+                        "null"
+                    ]
+                }
             }
-        },
-        "id": {
-            "title": "Release ID",
-            "description": "A unique identifier that identifies this release. A releaseID must be unique within a release-package and must not contain the # character.",
-            "type": "string"
-        },
-        "date": {
-            "title": "Release Date",
-            "format": "date-time",
-            "type": "string",
-            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order."
-        },
-        "tag": {
-            "title": "Release Tag",
-            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
-            "type": "array",
+        }, 
+        "StringNullDateTimeVersioned": {
             "items": {
-                "type": "string",
-                "enum": [
-                    "planning",
-                    "tender",
-                    "tenderAmendment",
-                    "tenderUpdate",
-                    "tenderCancellation",
-                    "award",
-                    "awardUpdate",
-                    "awardCancellation",
-                    "contract",
-                    "contractUpdate",
-                    "contractAmendment",
-                    "implementation",
-                    "implementationUpdate",
-                    "contractTermination",
-                    "compiled"
-                ]
-            }
-        },
-        "ocid": {
-            "title": "Open Contracting ID",
-            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)",
-            "type": "string"
+                "properties": {
+                    "releaseDate": {
+                        "type": "string", 
+                        "format": "date-time"
+                    }, 
+                    "releaseID": {
+                        "type": "string"
+                    }, 
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "value": {
+                        "type": [
+                            "string", 
+                            "null"
+                        ], 
+                        "format": "date-time"
+                    }
+                }
+            }, 
+            "type": "array"
+        }, 
+        "StringNullUriVersioned": {
+            "items": {
+                "properties": {
+                    "releaseDate": {
+                        "type": "string", 
+                        "format": "date-time"
+                    }, 
+                    "releaseID": {
+                        "type": "string"
+                    }, 
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "value": {
+                        "type": [
+                            "string", 
+                            "null"
+                        ], 
+                        "format": "uri"
+                    }
+                }
+            }, 
+            "type": "array"
+        }, 
+        "StringNullVersioned": {
+            "items": {
+                "properties": {
+                    "releaseDate": {
+                        "type": "string", 
+                        "format": "date-time"
+                    }, 
+                    "releaseID": {
+                        "type": "string"
+                    }, 
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        }, 
+                        "type": "array"
+                    }, 
+                    "value": {
+                        "type": [
+                            "string", 
+                            "null"
+                        ]
+                    }
+                }
+            }, 
+            "type": "array"
         }
-    },
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "required": [
-        "ocid",
-        "id",
-        "date",
-        "tag",
-        "initiationType"
-    ]
+    }
 }


### PR DESCRIPTION
Previously there was nested versioning, which didn't make sense, and
contradicted the docs.

To do this we've moved away from using jsonmerge to generating the
versioned schema with some new custom code.

This is part of the 1.0.1 schema changes https://github.com/open-contracting/standard/pull/305, but has its own pull request to make it easier to review the largish diff.

<!---
@huboard:{"order":150.0,"milestone_order":304,"custom_state":"archived"}
-->
