### PR TITLE
[#311] 1.0.1 Schema updates

### DIFF
--- a/standard/schema/codelists/awardStatus.csv
+++ b/standard/schema/codelists/awardStatus.csv
@@ -2,4 +2,4 @@ Category,Code,Title_en,Description_en,Source
 ,pending,Pending,"This award has been proposed, but is not yet in force. This may be due to a cooling off period, or some other process.",
 ,active,Active,"This award has been made, and is currently in force.",
 ,cancelled,Cancelled,This award has been cancelled.,
-,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers). The reason that the award did not suceed will be given in the statusDescription field.",
+,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers).",

--- a/standard/schema/codelists/documentType.csv
+++ b/standard/schema/codelists/documentType.csv
@@ -1,7 +1,7 @@
 Category,Code,Title_en,Description_en,Source
-basic,Tender notice,Tender Notice,"The formal notice that gives details of a tender. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
-basic,Award notice,Award Notice,"The formal notice that gives details of the contract award. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
-basic,Contract notice,Contract Notice,"The formal notice that gives details of a contract being signed and valid to start implementation. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
+basic,tenderNotice,Tender Notice,"The formal notice that gives details of a tender. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
+basic,awardNotice,Award Notice,"The formal notice that gives details of the contract award. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
+basic,contractNotice,Contract Notice,"The formal notice that gives details of a contract being signed and valid to start implementation. This may be a link to a downloadable document, to a web page, or to an official gazette in which the notice is contained. ",
 basic,completionCertificate,Completion certificate,,
 basic,procurementPlan,Procurement Plan,,
 basic,biddingDocuments,Bidding Documents,"Information for potential suppliers, describing the goals of the contract (e.g. goods and services to be procured), and the bidding process.",

--- a/standard/schema/record-package-schema.json
+++ b/standard/schema/record-package-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/record-package-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__1/record-package-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Record package",
     "description": "The record package contains a list of records along with some publishing meta data. The records pull together all the releases under a single Open Contracting ID and compile them into the latest version of the information along with the history of any data changes.",
@@ -123,7 +123,7 @@
                             "description": "A list of releases, with all the data. The releases MUST be sorted into date order in the array, from oldest (at position 0) to newest (last).",
                             "type": "array",
                             "items": {
-                                "$ref": "http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json"
+                                "$ref": "http://standard.open-contracting.org/schema/1__0__1/release-schema.json"
                             },
                             "minItems": 1
                         }
@@ -132,12 +132,12 @@
                 "compiledRelease": {
                     "title": "Compiled release",
                     "description": "This is the latest version of all the contracting data, it has the same schema as an open contracting release.",
-                    "$ref": "http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json"
+                    "$ref": "http://standard.open-contracting.org/schema/1__0__1/release-schema.json"
                 },
                 "versionedRelease": {
                     "title": "Versioned release",
                     "description": "This contains the history of the data in the compiledRecord. With all versions of the information and the release they came from.",
-                    "$ref": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json"
+                    "$ref": "http://standard.open-contracting.org/schema/1__0__1/versioned-release-validation-schema.json"
                 }
             },
             "required": ["ocid", "releases"]

--- a/standard/schema/record-package-schema.json
+++ b/standard/schema/record-package-schema.json
@@ -16,18 +16,23 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "title":"Name",
+                    "description":"The name of the organisation or department responsible for publishing this data.",
                     "type": "string"
                 },
                 "scheme": {
+                    "title":"Scheme",
                     "description": "The scheme that holds the unique identifiers used to identify the item being identified.",
-                    "type": ["string", "null"],
-                    "format": "uri"
+                    "type": ["string", "null"]
                 },
                 "uid": {
-                    "description": "The unique ID for this entity under the given ID scheme.",
+                    "title":"uid",
+                    "description": "The unique ID for this entity under the given ID scheme. Note the use of 'uid' rather than 'id'. See issue #245.",
                     "type": ["string", "null"]
                 },
                 "uri": {
+                    "title":"URI",
+                    "description":"A URI to identify the publisher.",
                     "type": ["string", "null"],
                     "format" : "uri"
                 }

--- a/standard/schema/release-package-schema.json
+++ b/standard/schema/release-package-schema.json
@@ -28,18 +28,23 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "title":"Name",
+                    "description":"The name of the organisation or department responsible for publishing this data.",
                     "type": "string"
                 },
                 "scheme": {
+                    "title":"Scheme",
                     "description": "The scheme that holds the unique identifiers used to identify the item being identified.",
-                    "type": ["string", "null"],
-                    "format": "uri"
+                    "type": ["string", "null"]
                 },
                 "uid": {
-                    "description": "The unique ID for this entity under the given ID scheme.",
+                    "title":"uid",
+                    "description": "The unique ID for this entity under the given ID scheme. Note the use of 'uid' rather than 'id'. See issue #245.",
                     "type": ["string", "null"]
                 },
                 "uri": {
+                    "title":"URI",
+                    "description":"A URI to identify the publisher.",
                     "type": ["string", "null"],
                     "format" : "uri"
                 }
@@ -47,7 +52,7 @@
             "required": ["name"]
         },
         "license": {
-            "description": "A link to the license that applies to the data in this datapackage. A Public Domain Dedication or [Open Definition Conformant](http://opendefinition.org/licenses/) license is strongly recommended. The canonical URI of the license should be used. Documents linked from this file may be under other license conditions. ",
+            "description": "A link to the license that applies to the data in this package. A Public Domain Dedication or [Open Definition Conformant](http://opendefinition.org/licenses/) license is strongly recommended. The canonical URI of the license should be used. Documents linked from this file may be under other license conditions. ",
             "type": ["string", "null"],
             "format": "uri"
         },

--- a/standard/schema/release-package-schema.json
+++ b/standard/schema/release-package-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/release-package-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__1/release-package-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Release Package",
     "description": "Note that all releases within a release package must have a unique releaseID within this release package.",
@@ -20,7 +20,7 @@
         "releases": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json" },
+            "items": { "$ref": "http://standard.open-contracting.org/schema/1__0__1/release-schema.json" },
             "uniqueItems": true
         },
         "publisher": { 

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -289,7 +289,7 @@
                     "title": "Award Status",
                     "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
                     "type": ["string", "null"],
-                    "enum": ["pending", "active", "cancelled", "unsuccessful"],
+                    "enum": ["pending", "active", "cancelled", "unsuccessful", null],
                     "mergeStrategy": "ocdsVersion"
                 },
                 "date": {
@@ -377,7 +377,7 @@
                     "title": "Contract Status",
                     "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
                     "type": ["string", "null"],
-                    "enum": ["pending", "active", "cancelled", "terminated"],
+                    "enum": ["pending", "active", "cancelled", "terminated", null],
                     "mergeStrategy": "ocdsVersion"
                 },
                 "period": {

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/release-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__1/release-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Release",
     "type": "object",

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -584,7 +584,6 @@
             "type": "object",
             "title": "Budget Information",
             "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-            "mergeStrategy": "ocdsVersion",
             "properties": {
                 "source": {
                     "title": "Data Source",

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -12,7 +12,7 @@
         },
         "id": {
             "title": "Release ID",
-            "description": "A unique identifier that identifies this release. A releaseID must be unique within a release-package and must not contain the # character.",
+            "description": "A unique identifier that identifies this release. A release ID must be unique within a release-package and must not contain the # character.",
             "type": "string",
             "mergeStrategy": "ocdsOmit"
         },

--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -7,7 +7,7 @@ def get_versioned_validation_schema(versioned_release):
     merger = jsonmerge.Merger(versioned_release)
 
     versioned_validation_schema = merger.get_schema()
-    versioned_validation_schema["id"] = "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json"  # nopep8
+    versioned_validation_schema["id"] = "http://standard.open-contracting.org/schema/1__0__1/versioned-release-validation-schema.json"  # nopep8
     versioned_validation_schema["$schema"] = "http://json-schema.org/draft-04/schema#"  # nopep8
     versioned_validation_schema["title"] = "Schema for a compiled, versioned Open Contracting Release."  # nopep8
 

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -2089,7 +2089,7 @@
             "type": "object"
         }
     },
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__1/versioned-release-validation-schema.json",
     "definitions": {
         "Transaction": {
             "title": "Transaction Information",

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -1,88 +1,182 @@
 {
-    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
+    "title": "Schema for a compiled, versioned Open Contracting Release.",
     "properties": {
-        "id": {
-            "type": "string",
-            "title": "Release ID",
-            "description": "A unique identifier that identifies this release. A release ID must be unique within a release-package and must not contain the # character."
-        },
         "planning": {
+            "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
             "properties": {
                 "rationale": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document.",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 },
                 "budget": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
+                    "title": "Budget Information",
+                    "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+                    "properties": {
+                        "amount": {
+                            "properties": {
+                                "amount": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Amount as a number.",
+                                                "minimum": 0,
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "currency": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The currency in 3-letter ISO 4217 format.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
+                            "type": "object"
+                        },
+                        "description": {
+                            "items": {
                                 "properties": {
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion",
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
+                                    "releaseID": {
+                                        "type": "string"
                                     },
-                                    "source": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "mergeStrategy": "ocdsVersion"
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
                                     },
-                                    "project": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
+                                    "releaseTag": {
+                                        "type": "string"
                                     },
-                                    "description": {
-                                        "mergeStrategy": "ocdsVersion",
+                                    "value": {
                                         "title": "Budget Source",
                                         "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
                                         "type": [
                                             "string",
                                             "null"
                                         ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
                                     },
-                                    "projectID": {
-                                        "mergeStrategy": "ocdsVersion",
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "source": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Data Source",
+                                        "format": "uri",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "projectID": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
                                         "title": "Project Identifier",
                                         "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
                                         "type": [
@@ -90,62 +184,93 @@
                                             "integer",
                                             "null"
                                         ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
                                     },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
                                     },
-                                    "uri": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "format": "uri",
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
                                         "title": "Linked budget information",
+                                        "format": "uri",
                                         "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
                                         "type": [
                                             "string",
                                             "null"
                                         ]
                                     }
-                                },
-                                "patternProperties": {
-                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "project": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
                                     },
-                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
                                     },
-                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
                                         "type": [
                                             "string",
                                             "null"
                                         ]
                                     }
-                                },
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-                                "type": "object",
-                                "title": "Budget Information"
+                                }
                             },
-                            "releaseID": {
-                                "type": "string"
-                            }
+                            "type": "array"
                         }
                     },
-                    "type": "array"
+                    "patternProperties": {
+                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
                 },
                 "documents": {
+                    "description": "A list of documents related to the planning process.",
                     "items": {
                         "$ref": "#/definitions/Document"
                     },
-                    "type": "array",
-                    "description": "A list of documents related to the planning process."
+                    "type": "array"
                 }
             },
-            "type": "object",
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
@@ -154,86 +279,522 @@
                     ]
                 }
             },
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender"
+            "type": "object"
         },
-        "contracts": {
-            "uniqueItems": true,
-            "description": "Information from the contract creation phase of the procurement process.",
-            "items": {
-                "$ref": "#/definitions/Contract"
-            },
-            "type": "array",
-            "title": "Contracts"
+        "id": {
+            "title": "Release ID",
+            "description": "A unique identifier that identifies this release. A release ID must be unique within a release-package and must not contain the # character.",
+            "type": "string"
         },
-        "ocid": {
-            "type": "string",
-            "title": "Open Contracting ID",
-            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)"
+        "date": {
+            "title": "Release Date",
+            "format": "date-time",
+            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order.",
+            "type": "string"
         },
-        "language": {
-            "items": {
-                "properties": {
-                    "releaseTag": {
-                        "type": "string"
+        "buyer": {
+            "title": "Organization",
+            "description": "An organization.",
+            "properties": {
+                "additionalIdentifiers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                },
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
                     },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
+                    "type": "array"
+                },
+                "identifier": {
+                    "properties": {
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The legally registered name of the organization.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The identifier of the organization in the selected scheme.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
                     },
-                    "value": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "default": "en",
-                        "title": "Release language",
-                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended."
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
                     },
-                    "releaseID": {
-                        "type": "string"
-                    }
+                    "type": "object"
+                },
+                "contactPoint": {
+                    "description": "An person, contact point or department to contact in relation to this contracting process.",
+                    "properties": {
+                        "faxNumber": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "telephone": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A web address for the contact point/person.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "email": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The e-mail address of the contact point/person.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "address": {
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                    "properties": {
+                        "postalCode": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The postal code. For example, 94043.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "region": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The region. For example, CA.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "countryName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The country name. For example, United States.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "streetAddress": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "locality": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The locality. For example, Mountain View.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
             },
-            "type": "array"
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
         },
         "initiationType": {
             "items": {
                 "properties": {
-                    "releaseTag": {
+                    "releaseID": {
                         "type": "string"
                     },
                     "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseTag": {
+                        "type": "string"
                     },
                     "value": {
-                        "type": "string",
                         "title": "Initiation type",
                         "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
+                        "type": "string",
                         "enum": [
                             "tender"
                         ]
-                    },
-                    "releaseID": {
-                        "type": "string"
                     }
                 }
             },
             "type": "array"
         },
-        "awards": {
-            "uniqueItems": true,
-            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+        "language": {
             "items": {
-                "$ref": "#/definitions/Award"
+                "properties": {
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseTag": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "title": "Release language",
+                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended.",
+                        "default": "en",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
             },
-            "type": "array",
-            "title": "Awards"
+            "type": "array"
+        },
+        "ocid": {
+            "title": "Open Contracting ID",
+            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)",
+            "type": "string"
         },
         "tag": {
+            "title": "Release Tag",
             "items": {
-                "type": "string",
                 "enum": [
                     "planning",
                     "tender",
@@ -250,1571 +811,61 @@
                     "implementationUpdate",
                     "contractTermination",
                     "compiled"
-                ]
+                ],
+                "type": "string"
             },
-            "type": "array",
-            "title": "Release Tag",
-            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields."
+            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
+            "type": "array"
         },
-        "buyer": {
-            "properties": {
-                "address": {
-                    "properties": {
-                        "region": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "locality": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "countryName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "streetAddress": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "postalCode": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
-                },
-                "identifier": {
-                    "properties": {
-                        "id": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "uri": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "scheme": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "legalName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "contactPoint": {
-                    "properties": {
-                        "faxNumber": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "url": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A web address for the contact point/person.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "name": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "email": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "telephone": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "description": "An person, contact point or department to contact in relation to this contracting process."
-                },
-                "additionalIdentifiers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
+        "contracts": {
+            "title": "Contracts",
+            "description": "Information from the contract creation phase of the procurement process.",
+            "items": {
+                "$ref": "#/definitions/Contract"
             },
-            "type": "object",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
+            "uniqueItems": true,
+            "type": "array"
+        },
+        "awards": {
+            "title": "Awards",
+            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "items": {
+                "$ref": "#/definitions/Award"
             },
-            "title": "Organization",
-            "description": "An organization."
+            "uniqueItems": true,
+            "type": "array"
         },
         "tender": {
-            "required": [
-                "id"
-            ],
+            "title": "Tender",
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
             "properties": {
-                "id": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "procurementMethodRationale": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "tenderPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "eligibilityCriteria": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "items": {
-                    "uniqueItems": true,
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "type": "array",
-                    "title": "Items to be procured"
-                },
                 "documents": {
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
                     "items": {
                         "$ref": "#/definitions/Document"
                     },
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include."
-                },
-                "hasEnquiries": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
                     "type": "array"
                 },
-                "awardCriteria": {
+                "id": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
                                 "type": [
                                     "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "awardPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "milestones": {
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender."
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "tenderers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "All entities who submit a tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "procuringEntity": {
-                    "properties": {
-                        "address": {
-                            "properties": {
-                                "region": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "locality": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "countryName": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "streetAddress": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "postalCode": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
-                        },
-                        "identifier": {
-                            "properties": {
-                                "id": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "uri": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                                "format": "uri"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "scheme": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "legalName": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "properties": {
-                                "faxNumber": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "url": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A web address for the contact point/person.",
-                                                "format": "uri"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "name": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "email": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "telephone": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "description": "An person, contact point or department to contact in relation to this contracting process."
-                        },
-                        "additionalIdentifiers": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        },
-                                        "type": "array",
-                                        "uniqueItems": true,
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "name": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Organization",
-                    "description": "An organization."
-                },
-                "enquiryPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "awardCriteriaDetails": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "minValue": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "value": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "amendment": {
-                    "properties": {
-                        "rationale": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "changes": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "date": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "title": "Amendment Date",
-                                        "description": "The data of this amendment.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "numberOfTenderers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "submissionMethodDetails": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                    "integer"
+                                ]
                             }
                         }
                     },
@@ -1823,28 +874,130 @@
                 "procurementMethod": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
                                 "enum": [
                                     "open",
                                     "selective",
                                     "limited",
                                     null
                                 ]
-                            },
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardCriteriaDetails": {
+                    "items": {
+                        "properties": {
                             "releaseID": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Any detailed or further information on the award or selection criteria.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "procurementMethodRationale": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             }
                         }
                     },
@@ -1853,20 +1006,23 @@
                 "status": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
                                 "enum": [
                                     "planned",
                                     "active",
@@ -1875,9 +1031,739 @@
                                     "complete",
                                     null
                                 ]
-                            },
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "hasEnquiries": {
+                    "items": {
+                        "properties": {
                             "releaseID": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process.",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "description": "All entities who submit a tender.",
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "amendment": {
+                    "title": "Amendment information",
+                    "properties": {
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ",
+                                                    "type": "string"
+                                                },
+                                                "former_value": {
+                                                    "description": "The previous value of the changed property, in whatever type the property is.",
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An explanation for the amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "description": "The data of this amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "minValue": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "procuringEntity": {
+                    "title": "Organization",
+                    "description": "An organization.",
+                    "properties": {
+                        "additionalIdentifiers": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        },
+                                        "uniqueItems": true,
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "identifier": {
+                            "properties": {
+                                "legalName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The legally registered name of the organization.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "id": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The identifier of the organization in the selected scheme.",
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "scheme": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "uri": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "format": "uri",
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "contactPoint": {
+                            "description": "An person, contact point or department to contact in relation to this contracting process.",
+                            "properties": {
+                                "faxNumber": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "telephone": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "url": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "format": "uri",
+                                                "description": "A web address for the contact point/person.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "email": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The e-mail address of the contact point/person.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "name": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "address": {
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                            "properties": {
+                                "postalCode": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The postal code. For example, 94043.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "region": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The region. For example, CA.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "countryName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The country name. For example, United States.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "streetAddress": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "locality": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The locality. For example, Mountain View.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "awardPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "numberOfTenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "definition": "The number of entities who submit a tender.",
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
                             }
                         }
                     },
@@ -1886,32 +1772,301 @@
                 "submissionMethod": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
                                 "items": {
                                     "type": "string"
                                 },
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
                                 "type": [
                                     "array",
                                     "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)"
-                            },
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "eligibilityCriteria": {
+                    "items": {
+                        "properties": {
                             "releaseID": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A description of any eligibility criteria for potential suppliers.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Tender title",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Tender description",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "items": {
+                    "title": "Items to be procured",
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "enquiryPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tenderPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "milestones": {
+                    "description": "A list of milestones associated with the tender.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "type": "array"
+                },
+                "awardCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethodDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 }
             },
+            "required": [
+                "id"
+            ],
             "patternProperties": {
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
@@ -1929,225 +2084,99 @@
                         "string",
                         "null"
                     ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
                 }
             },
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "type": "object",
-            "title": "Tender"
-        },
-        "date": {
-            "type": "string",
-            "title": "Release Date",
-            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order.",
-            "format": "date-time"
+            "type": "object"
         }
     },
+    "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
     "definitions": {
-        "Milestone": {
-            "required": [
-                "id"
-            ],
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
+        "Transaction": {
+            "title": "Transaction Information",
+            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data.",
             "properties": {
+                "amount": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
                 "id": {
+                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference.",
                     "type": [
                         "string",
                         "integer"
-                    ],
-                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
+                    ]
                 },
-                "dateModified": {
+                "source": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct.",
-                                "format": "date-time"
-                            },
                             "releaseID": {
                                 "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "items": {
-                        "properties": {
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
                             "releaseTag": {
                                 "type": "string"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
                             "value": {
+                                "title": "Data Source",
+                                "format": "uri",
+                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "A description of the milestone."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "documents": {
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "type": "array",
-                    "uniqueItems": true,
-                    "description": "List of documents associated with this milestone."
-                },
-                "dueDate": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the milestone is due.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "status": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status).",
-                                "enum": [
-                                    "met",
-                                    "notMet",
-                                    "partiallyMet",
-                                    null
                                 ]
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Milestone title"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            }
-        },
-        "Classification": {
-            "properties": {
-                "id": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The classification code drawn from the selected scheme."
-                            },
-                            "releaseID": {
-                                "type": "string"
                             }
                         }
                     },
@@ -2156,23 +2185,907 @@
                 "uri": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "title": "Linked spending information",
+                                "format": "uri",
+                                "description": "A URI pointing directly to a machine-readable record about this spending transaction.",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
-                                "format": "uri"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "receiverOrganization": {
+                    "properties": {
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The legally registered name of the organization.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
                             },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The identifier of the organization in the selected scheme.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "providerOrganization": {
+                    "properties": {
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The legally registered name of the organization.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The identifier of the organization in the selected scheme.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "date": {
+                    "items": {
+                        "properties": {
                             "releaseID": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The date of the transaction",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "ContactPoint": {
+            "description": "An person, contact point or department to contact in relation to this contracting process.",
+            "properties": {
+                "faxNumber": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The fax number of the contact point/person. This should include the international dialling code.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "telephone": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The telephone number of the contact point/person. This should include the international dialling code.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "url": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "uri",
+                                "description": "A web address for the contact point/person.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "email": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The e-mail address of the contact point/person.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Organization": {
+            "title": "Organization",
+            "description": "An organization.",
+            "properties": {
+                "additionalIdentifiers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                },
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "identifier": {
+                    "properties": {
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The legally registered name of the organization.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The identifier of the organization in the selected scheme.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "contactPoint": {
+                    "description": "An person, contact point or department to contact in relation to this contracting process.",
+                    "properties": {
+                        "faxNumber": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "telephone": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A web address for the contact point/person.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "email": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The e-mail address of the contact point/person.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "address": {
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                    "properties": {
+                        "postalCode": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The postal code. For example, 94043.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "region": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The region. For example, CA.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "countryName": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The country name. For example, United States.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "streetAddress": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "locality": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The locality. For example, Mountain View.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Identifier": {
+            "properties": {
+                "legalName": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The legally registered name of the organization.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The identifier of the organization in the selected scheme.",
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
                             }
                         }
                     },
@@ -2181,22 +3094,86 @@
                 "scheme": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                            },
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
                             "releaseID": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "uri",
+                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Award": {
+            "title": "Award",
+            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "properties": {
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Award title",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             }
                         }
                     },
@@ -2205,134 +3182,642 @@
                 "description": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "Award description",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "title": "Award ID",
+                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "items": {
+                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "type": "array",
+                    "title": "Items Awarded",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "date": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award date",
+                                "format": "date-time",
+                                "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "contractPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "amendment": {
+                    "title": "Amendment information",
+                    "properties": {
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ",
+                                                    "type": "string"
+                                                },
+                                                "former_value": {
+                                                    "description": "The previous value of the changed property, in whatever type the property is.",
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An explanation for the amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "description": "The data of this amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "suppliers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks.",
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "documents": {
+                    "description": "All documents and attachments related to the award, including any notices.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award Status",
+                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "A textual description or title for the code."
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    null
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 }
             },
-            "type": "object",
+            "required": [
+                "id"
+            ],
             "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
-            }
+            },
+            "type": "object"
         },
-        "Amendment": {
+        "Planning": {
+            "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
             "properties": {
                 "rationale": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document.",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "An explanation for the amendment."
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 },
-                "changes": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "properties": {
-                                        "property": {
-                                            "type": "string",
-                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                        },
-                                        "former_value": {
-                                            "type": [
-                                                "string",
-                                                "number",
-                                                "integer",
-                                                "array",
-                                                "object",
-                                                "null"
-                                            ],
-                                            "description": "The previous value of the changed property, in whatever type the property is."
+                "budget": {
+                    "title": "Budget Information",
+                    "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+                    "properties": {
+                        "amount": {
+                            "properties": {
+                                "amount": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Amount as a number.",
+                                                "minimum": 0,
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            }
                                         }
                                     },
-                                    "type": "object"
+                                    "type": "array"
                                 },
-                                "title": "Amended fields",
-                                "description": "Comma-seperated list of affected fields.",
-                                "type": "array"
+                                "currency": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The currency in 3-letter ISO 4217 format.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
                             },
-                            "releaseID": {
-                                "type": "string"
-                            }
+                            "type": "object"
+                        },
+                        "description": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Budget Source",
+                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "source": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Data Source",
+                                        "format": "uri",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "projectID": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Project Identifier",
+                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Linked budget information",
+                                        "format": "uri",
+                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "project": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
                         }
                     },
-                    "type": "array"
-                },
-                "date": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "title": "Amendment Date",
-                                "description": "The data of this amendment.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
+                    "patternProperties": {
+                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         }
+                    },
+                    "type": "object"
+                },
+                "documents": {
+                    "description": "A list of documents related to the planning process.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
                     },
                     "type": "array"
                 }
             },
-            "type": "object",
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
@@ -2341,70 +3826,428 @@
                     ]
                 }
             },
-            "title": "Amendment information"
+            "type": "object"
         },
-        "Budget": {
+        "Address": {
+            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
             "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion",
-                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
+                "postalCode": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The postal code. For example, 94043.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
-                "source": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "uri",
-                    "title": "Data Source",
-                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                    "mergeStrategy": "ocdsVersion"
+                "region": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The region. For example, CA.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
-                "project": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Project Title",
-                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                "countryName": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The country name. For example, United States.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "streetAddress": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "locality": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The locality. For example, Mountain View.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
+                }
+            },
+            "type": "object"
+        },
+        "Item": {
+            "description": "A good, service, or work to be contracted.",
+            "properties": {
+                "classification": {
+                    "properties": {
+                        "description": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "A textual description or title for the code.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The classification code drawn from the selected scheme.",
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "uri",
+                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
                 },
                 "description": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Budget Source",
-                    "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A description of the goods, services to be provided.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items.",
                     "type": [
                         "string",
-                        "null"
+                        "integer"
                     ]
                 },
-                "projectID": {
-                    "mergeStrategy": "ocdsVersion",
-                    "title": "Project Identifier",
-                    "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
+                "additionalClassifications": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
+                                "items": {
+                                    "$ref": "#/definitions/Classification"
+                                },
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
-                "amount": {
-                    "$ref": "#/definitions/Value",
-                    "description": "The value of the budget line item."
+                "quantity": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The number of units required",
+                                "minimum": 0,
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
-                "uri": {
-                    "mergeStrategy": "ocdsVersion",
-                    "format": "uri",
-                    "title": "Linked budget information",
-                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                "unit": {
+                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit.",
+                    "properties": {
+                        "value": {
+                            "properties": {
+                                "amount": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Amount as a number.",
+                                                "minimum": 0,
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "currency": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The currency in 3-letter ISO 4217 format.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Name of the unit",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "patternProperties": {
@@ -2413,8 +4256,2492 @@
                         "string",
                         "null"
                     ]
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "type": "object"
+        },
+        "Amendment": {
+            "title": "Amendment information",
+            "properties": {
+                "changes": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Amended fields",
+                                "description": "Comma-seperated list of affected fields.",
+                                "items": {
+                                    "properties": {
+                                        "property": {
+                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ",
+                                            "type": "string"
+                                        },
+                                        "former_value": {
+                                            "description": "The previous value of the changed property, in whatever type the property is.",
+                                            "type": [
+                                                "string",
+                                                "number",
+                                                "integer",
+                                                "array",
+                                                "object",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
-                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "rationale": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "An explanation for the amendment.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "date": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Amendment Date",
+                                "format": "date-time",
+                                "description": "The data of this amendment.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Classification": {
+            "properties": {
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A textual description or title for the code.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The classification code drawn from the selected scheme.",
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "scheme": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "uri",
+                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Document": {
+            "title": "Document",
+            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
+            "properties": {
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The document title.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "format": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "documentType": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "language": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "dateModified": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "Date that the document was last modified",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "datePublished": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "url": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "uri",
+                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Tender": {
+            "title": "Tender",
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
+            "properties": {
+                "documents": {
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procurementMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "open",
+                                    "selective",
+                                    "limited",
+                                    null
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardCriteriaDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Any detailed or further information on the award or selection criteria.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "procurementMethodRationale": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "planned",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    "complete",
+                                    null
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "hasEnquiries": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process.",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "description": "All entities who submit a tender.",
+                                "uniqueItems": true,
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "amendment": {
+                    "title": "Amendment information",
+                    "properties": {
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ",
+                                                    "type": "string"
+                                                },
+                                                "former_value": {
+                                                    "description": "The previous value of the changed property, in whatever type the property is.",
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An explanation for the amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "description": "The data of this amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "minValue": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "procuringEntity": {
+                    "title": "Organization",
+                    "description": "An organization.",
+                    "properties": {
+                        "additionalIdentifiers": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        },
+                                        "uniqueItems": true,
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "identifier": {
+                            "properties": {
+                                "legalName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The legally registered name of the organization.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "id": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The identifier of the organization in the selected scheme.",
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "scheme": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme).",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "uri": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "format": "uri",
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "contactPoint": {
+                            "description": "An person, contact point or department to contact in relation to this contracting process.",
+                            "properties": {
+                                "faxNumber": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "telephone": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "url": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "format": "uri",
+                                                "description": "A web address for the contact point/person.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "email": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The e-mail address of the contact point/person.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "name": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "address": {
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
+                            "properties": {
+                                "postalCode": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The postal code. For example, 94043.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "region": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The region. For example, CA.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "countryName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The country name. For example, United States.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "streetAddress": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "locality": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseID": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The locality. For example, Mountain View.",
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "awardPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "numberOfTenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "definition": "The number of entities who submit a tender.",
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
+                                "type": [
+                                    "array",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "eligibilityCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "A description of any eligibility criteria for potential suppliers.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Tender title",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Tender description",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "items": {
+                    "title": "Items to be procured",
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "enquiryPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tenderPeriod": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "milestones": {
+                    "description": "A list of milestones associated with the tender.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "type": "array"
+                },
+                "awardCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethodDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "patternProperties": {
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Implementation": {
+            "title": "Implementation",
+            "description": "Information during the performance / implementation stage of the contract.",
+            "properties": {
+                "transactions": {
+                    "description": "A list of the spending transactions made against this contract",
+                    "items": {
+                        "$ref": "#/definitions/Transaction"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "milestones": {
+                    "description": "As milestones are completed, milestone completions should be documented.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "documents": {
+                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "Contract": {
+            "title": "Contract",
+            "description": "Information regarding the signed contract between the buyer and supplier(s).",
+            "properties": {
+                "awardID": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Award ID",
+                                "description": "The award.id against which this contract is being issued.",
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "title": "Contract ID",
+                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "items": {
+                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "type": "array",
+                    "title": "Items Contracted",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    }
+                },
+                "period": {
+                    "title": "Period",
+                    "properties": {
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The start date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "format": "date-time",
+                                        "description": "The end date for the period.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "implementation": {
+                    "title": "Implementation",
+                    "description": "Information during the performance / implementation stage of the contract.",
+                    "properties": {
+                        "transactions": {
+                            "description": "A list of the spending transactions made against this contract",
+                            "items": {
+                                "$ref": "#/definitions/Transaction"
+                            },
+                            "uniqueItems": true,
+                            "type": "array"
+                        },
+                        "milestones": {
+                            "description": "As milestones are completed, milestone completions should be documented.",
+                            "items": {
+                                "$ref": "#/definitions/Milestone"
+                            },
+                            "uniqueItems": true,
+                            "type": "array"
+                        },
+                        "documents": {
+                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                            "items": {
+                                "$ref": "#/definitions/Document"
+                            },
+                            "uniqueItems": true,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "documents": {
+                    "description": "All documents and attachments related to the contract, including any notices.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "dateSigned": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Contract title",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "amendment": {
+                    "title": "Amendment information",
+                    "properties": {
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. ",
+                                                    "type": "string"
+                                                },
+                                                "former_value": {
+                                                    "description": "The previous value of the changed property, in whatever type the property is.",
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "An explanation for the amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "title": "Amendment Date",
+                                        "format": "date-time",
+                                        "description": "The data of this amendment.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": "object"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Contract Status",
+                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "terminated",
+                                    null
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Contract description",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id",
+                "awardID"
+            ],
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Period": {
+            "title": "Period",
+            "properties": {
+                "startDate": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The start date for the period.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "endDate": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The end date for the period.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "Value": {
+            "properties": {
+                "amount": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Amount as a number.",
+                                "minimum": 0,
+                                "type": [
+                                    "number",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "currency": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The currency in 3-letter ISO 4217 format.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "Budget": {
+            "title": "Budget Information",
+            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+            "properties": {
+                "amount": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Amount as a number.",
+                                        "minimum": 0,
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseID": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "format": "date-time",
+                                        "type": "string"
+                                    },
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "The currency in 3-letter ISO 4217 format.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Budget Source",
+                                "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "source": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Data Source",
+                                "format": "uri",
+                                "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "projectID": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Project Identifier",
+                                "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Linked budget information",
+                                "format": "uri",
+                                "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "project": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "title": "Project Title",
+                                "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
@@ -2425,4106 +6752,183 @@
                         "string",
                         "null"
                     ]
-                }
-            },
-            "mergeStrategy": "ocdsVersion",
-            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-            "type": "object",
-            "title": "Budget Information"
-        },
-        "Award": {
-            "required": [
-                "id"
-            ],
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "title": "Award ID",
-                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details."
                 },
-                "amendment": {
-                    "properties": {
-                        "rationale": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "changes": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "date": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "title": "Amendment Date",
-                                        "description": "The data of this amendment.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "value": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award description"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "documents": {
-                    "uniqueItems": true,
-                    "description": "All documents and attachments related to the award, including any notices.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "type": "array"
-                },
-                "items": {
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "type": "array",
-                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
-                    "title": "Items Awarded"
-                },
-                "contractPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "status": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "title": "Award Status",
-                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    null
-                                ]
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award title"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "suppliers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "date": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "title": "Award date",
-                                "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "type": "object",
-            "title": "Award"
-        },
-        "Contract": {
-            "required": [
-                "id",
-                "awardID"
-            ],
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "title": "Contract ID",
-                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details."
-                },
-                "period": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "implementation": {
-                    "properties": {
-                        "documents": {
-                            "uniqueItems": true,
-                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                            "items": {
-                                "$ref": "#/definitions/Document"
-                            },
-                            "type": "array"
-                        },
-                        "milestones": {
-                            "uniqueItems": true,
-                            "description": "As milestones are completed, milestone completions should be documented.",
-                            "items": {
-                                "$ref": "#/definitions/Milestone"
-                            },
-                            "type": "array"
-                        },
-                        "transactions": {
-                            "uniqueItems": true,
-                            "description": "A list of the spending transactions made against this contract",
-                            "items": {
-                                "$ref": "#/definitions/Transaction"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Implementation",
-                    "description": "Information during the performance / implementation stage of the contract."
-                },
-                "amendment": {
-                    "properties": {
-                        "rationale": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "changes": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "date": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "title": "Amendment Date",
-                                        "description": "The data of this amendment.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "items": {
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "type": "array",
-                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
-                    "title": "Items Contracted"
-                },
-                "value": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "awardID": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "title": "Award ID",
-                                "description": "The award.id against which this contract is being issued."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract description"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "documents": {
-                    "uniqueItems": true,
-                    "description": "All documents and attachments related to the contract, including any notices.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "type": "array"
-                },
-                "status": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "title": "Contract Status",
-                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "terminated",
-                                    null
-                                ]
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "dateSigned": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract title"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Information regarding the signed contract between the buyer and supplier(s).",
-            "type": "object",
-            "title": "Contract"
-        },
-        "Document": {
-            "required": [
-                "id"
-            ],
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
-                },
-                "dateModified": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Date that the document was last modified",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "language": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "documentType": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "format": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The document title."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "datePublished": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "url": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type.",
-                                "format": "uri"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
-            "type": "object",
-            "title": "Document"
-        },
-        "Implementation": {
-            "properties": {
-                "documents": {
-                    "uniqueItems": true,
-                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "type": "array"
-                },
-                "milestones": {
-                    "uniqueItems": true,
-                    "description": "As milestones are completed, milestone completions should be documented.",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "type": "array"
-                },
-                "transactions": {
-                    "uniqueItems": true,
-                    "description": "A list of the spending transactions made against this contract",
-                    "items": {
-                        "$ref": "#/definitions/Transaction"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "title": "Implementation",
-            "description": "Information during the performance / implementation stage of the contract."
-        },
-        "Organization": {
-            "properties": {
-                "address": {
-                    "properties": {
-                        "region": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "locality": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "countryName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "streetAddress": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "postalCode": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
-                },
-                "identifier": {
-                    "properties": {
-                        "id": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "uri": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "scheme": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "legalName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "contactPoint": {
-                    "properties": {
-                        "faxNumber": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "url": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A web address for the contact point/person.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "name": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "email": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "telephone": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "description": "An person, contact point or department to contact in relation to this contracting process."
-                },
-                "additionalIdentifiers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Organization",
-            "description": "An organization."
-        },
-        "Item": {
-            "required": [
-                "id"
-            ],
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
-                },
-                "additionalClassifications": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Classification"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "classification": {
-                    "properties": {
-                        "id": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The classification code drawn from the selected scheme."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "uri": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "scheme": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "description": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A textual description or title for the code."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the goods, services to be provided."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "unit": {
-                    "properties": {
-                        "name": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Name of the unit"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "value": {
-                            "properties": {
-                                "amount": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "number",
-                                                    "null"
-                                                ],
-                                                "description": "Amount as a number.",
-                                                "minimum": 0
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "currency": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The currency in 3-letter ISO 4217 format."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit."
-                },
-                "quantity": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The number of units required",
-                                "minimum": 0
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "description": "A good, service, or work to be contracted."
-        },
-        "Address": {
-            "properties": {
-                "region": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The region. For example, CA."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "locality": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The locality. For example, Mountain View."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "countryName": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The country name. For example, United States."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "streetAddress": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "postalCode": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The postal code. For example, 94043."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
-        },
-        "Identifier": {
-            "properties": {
-                "id": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The identifier of the organization in the selected scheme."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "uri": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                "format": "uri"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "scheme": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "legalName": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The legally registered name of the organization."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Transaction": {
-            "required": [
-                "id"
-            ],
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
-                },
-                "source": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "title": "Data Source",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                "format": "uri"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "providerOrganization": {
-                    "properties": {
-                        "id": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "uri": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "scheme": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "legalName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "amount": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "uri": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "title": "Linked spending information",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI pointing directly to a machine-readable record about this spending transaction.",
-                                "format": "uri"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "date": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date of the transaction",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "receiverOrganization": {
-                    "properties": {
-                        "id": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "uri": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                        "format": "uri"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "scheme": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "legalName": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "title": "Transaction Information",
-            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data."
-        },
-        "Period": {
-            "properties": {
-                "endDate": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The end date for the period.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "startDate": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The start date for the period.",
-                                "format": "date-time"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "title": "Period"
-        },
-        "Tender": {
-            "required": [
-                "id"
-            ],
-            "properties": {
-                "id": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "procurementMethodRationale": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "tenderPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "eligibilityCriteria": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "items": {
-                    "uniqueItems": true,
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    },
-                    "type": "array",
-                    "title": "Items to be procured"
-                },
-                "documents": {
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include."
-                },
-                "hasEnquiries": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "awardCriteria": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "awardPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "milestones": {
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender."
-                },
-                "description": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "tenderers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                },
-                                "type": "array",
-                                "uniqueItems": true,
-                                "description": "All entities who submit a tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "procuringEntity": {
-                    "properties": {
-                        "address": {
-                            "properties": {
-                                "region": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "locality": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "countryName": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "streetAddress": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "postalCode": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
-                        },
-                        "identifier": {
-                            "properties": {
-                                "id": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "uri": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
-                                                "format": "uri"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "scheme": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "legalName": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "properties": {
-                                "faxNumber": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "url": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "A web address for the contact point/person.",
-                                                "format": "uri"
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "name": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "email": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                },
-                                "telephone": {
-                                    "items": {
-                                        "properties": {
-                                            "releaseTag": {
-                                                "type": "string"
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseID": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "type": "object",
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "description": "An person, contact point or department to contact in relation to this contracting process."
-                        },
-                        "additionalIdentifiers": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        },
-                                        "type": "array",
-                                        "uniqueItems": true,
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "name": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Organization",
-                    "description": "An organization."
-                },
-                "enquiryPeriod": {
-                    "properties": {
-                        "endDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The end date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "startDate": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The start date for the period.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "title": "Period"
-                },
-                "awardCriteriaDetails": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "minValue": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "value": {
-                    "properties": {
-                        "amount": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number.",
-                                        "minimum": 0
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "currency": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object"
-                },
-                "amendment": {
-                    "properties": {
-                        "rationale": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "changes": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "items": {
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        },
-                        "date": {
-                            "items": {
-                                "properties": {
-                                    "releaseTag": {
-                                        "type": "string"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "title": "Amendment Date",
-                                        "description": "The data of this amendment.",
-                                        "format": "date-time"
-                                    },
-                                    "releaseID": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "numberOfTenderers": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "submissionMethodDetails": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "procurementMethod": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "status": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ]
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "submissionMethod": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "patternProperties": {
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "type": "object",
-            "title": "Tender"
-        },
-        "Value": {
-            "properties": {
-                "amount": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "number",
-                                    "null"
-                                ],
-                                "description": "Amount as a number.",
-                                "minimum": 0
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "currency": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The currency in 3-letter ISO 4217 format."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
                 }
             },
             "type": "object"
         },
-        "ContactPoint": {
+        "Milestone": {
+            "required": [
+                "id"
+            ],
             "properties": {
-                "faxNumber": {
+                "title": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "Milestone title",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 },
-                "url": {
+                "description": {
                     "items": {
                         "properties": {
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             },
                             "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "value": {
+                                "description": "A description of the milestone.",
                                 "type": [
                                     "string",
                                     "null"
-                                ],
-                                "description": "A web address for the contact point/person.",
-                                "format": "uri"
-                            },
-                            "releaseID": {
-                                "type": "string"
+                                ]
                             }
                         }
                     },
                     "type": "array"
                 },
-                "name": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "email": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The e-mail address of the contact point/person."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "telephone": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "id": {
+                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism.",
                     "type": [
                         "string",
-                        "null"
+                        "integer"
                     ]
-                }
-            },
-            "description": "An person, contact point or department to contact in relation to this contracting process."
-        },
-        "Planning": {
-            "properties": {
-                "rationale": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
-                },
-                "budget": {
-                    "items": {
-                        "properties": {
-                            "releaseTag": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "value": {
-                                "properties": {
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion",
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
-                                    },
-                                    "source": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
-                                    "project": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "description": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Budget Source",
-                                        "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "projectID": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "title": "Project Identifier",
-                                        "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ]
-                                    },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
-                                    },
-                                    "uri": {
-                                        "mergeStrategy": "ocdsVersion",
-                                        "format": "uri",
-                                        "title": "Linked budget information",
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                },
-                                "patternProperties": {
-                                    "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                },
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
-                                "type": "object",
-                                "title": "Budget Information"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "type": "array"
                 },
                 "documents": {
+                    "description": "List of documents associated with this milestone.",
                     "items": {
                         "$ref": "#/definitions/Document"
                     },
-                    "type": "array",
-                    "description": "A list of documents related to the planning process."
+                    "uniqueItems": true,
+                    "type": "array"
+                },
+                "dateModified": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "dueDate": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "format": "date-time",
+                                "description": "The date the milestone is due.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status).",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "met",
+                                    "notMet",
+                                    "partiallyMet",
+                                    null
+                                ]
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
             },
-            "type": "object",
             "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
                 }
             },
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender"
+            "type": "object"
         }
     },
-    "type": "object",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "required": [
         "ocid",
         "id",
@@ -6532,6 +6936,5 @@
         "tag",
         "initiationType"
     ],
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Schema for a compiled, versioned Open Contracting Release."
+    "type": "object"
 }

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -1,72 +1,22 @@
 {
-    "type": "object",
     "id": "http://ocds.open-contracting.org/standard/r/1__0__0/versioned-release-validation-schema.json",
-    "title": "Schema for a compiled, versioned Open Contracting Release.",
-    "definitions": {
-        "Value": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "number",
-                                    "null"
-                                ],
-                                "description": "Amount as a number."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "currency": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The currency in 3-letter ISO 4217 format."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
+    "properties": {
+        "id": {
+            "type": "string",
+            "title": "Release ID",
+            "description": "A unique identifier that identifies this release. A release ID must be unique within a release-package and must not contain the # character."
         },
-        "Planning": {
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
+        "planning": {
             "properties": {
                 "rationale": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -75,95 +25,85 @@
                                 ],
                                 "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
                             },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "budget": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "A list of documents related to the planning process.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "budget": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "value": {
-                                "type": "object",
-                                "title": "Budget Information",
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
                                 "properties": {
-                                    "source": {
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
                                     "id": {
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
                                         ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                                        "mergeStrategy": "ocdsVersion"
+                                        "mergeStrategy": "ocdsVersion",
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
                                     },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
-                                    },
-                                    "uri": {
-                                        "format": "uri",
-                                        "title": "Linked budget information",
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                    "source": {
                                         "type": [
                                             "string",
                                             "null"
                                         ],
+                                        "format": "uri",
+                                        "title": "Data Source",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
                                         "mergeStrategy": "ocdsVersion"
                                     },
+                                    "project": {
+                                        "mergeStrategy": "ocdsVersion",
+                                        "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
                                     "description": {
+                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Budget Source",
                                         "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
                                         "type": [
                                             "string",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     },
                                     "projectID": {
+                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Project Identifier",
                                         "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     },
-                                    "project": {
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                    "amount": {
+                                        "$ref": "#/definitions/Value",
+                                        "description": "The value of the budget line item."
+                                    },
+                                    "uri": {
+                                        "mergeStrategy": "ocdsVersion",
+                                        "format": "uri",
+                                        "title": "Linked budget information",
+                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
                                         "type": [
                                             "string",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     }
                                 },
                                 "patternProperties": {
@@ -185,17 +125,24 @@
                                             "null"
                                         ]
                                     }
-                                }
+                                },
+                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+                                "type": "object",
+                                "title": "Budget Information"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "documents": {
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array",
+                    "description": "A list of documents related to the planning process."
                 }
             },
             "type": "object",
@@ -206,717 +153,1557 @@
                         "null"
                     ]
                 }
-            }
+            },
+            "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender"
         },
-        "Transaction": {
-            "type": "object",
-            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data.",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
-                },
-                "amount": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Linked spending information",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A URI pointing directly to a machine-readable record about this spending transaction."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "providerOrganization": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
+        "contracts": {
+            "uniqueItems": true,
+            "description": "Information from the contract creation phase of the procurement process.",
+            "items": {
+                "$ref": "#/definitions/Contract"
+            },
+            "type": "array",
+            "title": "Contracts"
+        },
+        "ocid": {
+            "type": "string",
+            "title": "Open Contracting ID",
+            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)"
+        },
+        "language": {
+            "items": {
+                "properties": {
+                    "releaseTag": {
+                        "type": "string"
                     },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "receiverOrganization": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
+                    "releaseDate": {
+                        "type": "string",
+                        "format": "date-time"
                     },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date of the transaction"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "source": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Data Source",
-                                "format": "uri",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
+                    "value": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "default": "en",
+                        "title": "Release language",
+                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended."
+                    },
+                    "releaseID": {
+                        "type": "string"
                     }
                 }
             },
-            "title": "Transaction Information",
-            "required": [
-                "id"
-            ]
+            "type": "array"
         },
-        "Contract": {
+        "initiationType": {
+            "items": {
+                "properties": {
+                    "releaseTag": {
+                        "type": "string"
+                    },
+                    "releaseDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Initiation type",
+                        "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
+                        "enum": [
+                            "tender"
+                        ]
+                    },
+                    "releaseID": {
+                        "type": "string"
+                    }
+                }
+            },
+            "type": "array"
+        },
+        "awards": {
+            "uniqueItems": true,
+            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "items": {
+                "$ref": "#/definitions/Award"
+            },
+            "type": "array",
+            "title": "Awards"
+        },
+        "tag": {
+            "items": {
+                "type": "string",
+                "enum": [
+                    "planning",
+                    "tender",
+                    "tenderAmendment",
+                    "tenderUpdate",
+                    "tenderCancellation",
+                    "award",
+                    "awardUpdate",
+                    "awardCancellation",
+                    "contract",
+                    "contractUpdate",
+                    "contractAmendment",
+                    "implementation",
+                    "implementationUpdate",
+                    "contractTermination",
+                    "compiled"
+                ]
+            },
+            "type": "array",
+            "title": "Release Tag",
+            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields."
+        },
+        "buyer": {
+            "properties": {
+                "address": {
+                    "properties": {
+                        "region": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The region. For example, CA."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "locality": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The locality. For example, Mountain View."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "countryName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The country name. For example, United States."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "streetAddress": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "postalCode": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The postal code. For example, 94043."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
+                },
+                "identifier": {
+                    "properties": {
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "contactPoint": {
+                    "properties": {
+                        "faxNumber": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A web address for the contact point/person.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "email": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The e-mail address of the contact point/person."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "telephone": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "description": "An person, contact point or department to contact in relation to this contracting process."
+                },
+                "additionalIdentifiers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
             "type": "object",
             "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
                 }
             },
-            "title": "Contract",
-            "description": "Information regarding the signed contract between the buyer and supplier(s).",
+            "title": "Organization",
+            "description": "An organization."
+        },
+        "tender": {
+            "required": [
+                "id"
+            ],
             "properties": {
-                "period": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "All documents and attachments related to the contract, including any notices.",
-                    "uniqueItems": true
-                },
                 "id": {
-                    "title": "Contract ID",
-                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
-                    "type": [
-                        "string",
-                        "integer"
-                    ]
-                },
-                "implementation": {
-                    "type": "object",
-                    "description": "Information during the performance / implementation stage of the contract.",
-                    "properties": {
-                        "milestones": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Milestone"
-                            },
-                            "description": "As milestones are completed, milestone completions should be documented.",
-                            "uniqueItems": true
-                        },
-                        "transactions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Transaction"
-                            },
-                            "description": "A list of the spending transactions made against this contract",
-                            "uniqueItems": true
-                        },
-                        "documents": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Document"
-                            },
-                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                            "uniqueItems": true
-                        }
-                    },
-                    "title": "Implementation"
-                },
-                "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "title": "Contract Status",
-                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "terminated"
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardID": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "value": {
-                                "title": "Award ID",
-                                "description": "The award.id against which this contract is being issued.",
                                 "type": [
                                     "string",
                                     "integer"
-                                ]
+                                ],
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procurementMethodRationale": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateSigned": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "format": "date-time",
-                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature."
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "eligibilityCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "Contract title"
+                                "description": "A description of any eligibility criteria for potential suppliers."
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Contract description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "items": {
-                    "type": "array",
                     "uniqueItems": true,
-                    "minItems": 1,
-                    "title": "Items Contracted",
-                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
                     "items": {
                         "$ref": "#/definitions/Item"
-                    }
+                    },
+                    "type": "array",
+                    "title": "Items to be procured"
                 },
-                "amendment": {
+                "documents": {
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array",
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include."
+                },
+                "hasEnquiries": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "milestones": {
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "type": "array",
+                    "description": "A list of milestones associated with the tender."
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender description"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "All entities who submit a tender."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procuringEntity": {
+                    "properties": {
+                        "address": {
+                            "properties": {
+                                "region": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The region. For example, CA."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "locality": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The locality. For example, Mountain View."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "countryName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The country name. For example, United States."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "streetAddress": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "postalCode": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The postal code. For example, 94043."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
+                        },
+                        "identifier": {
+                            "properties": {
+                                "id": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ],
+                                                "description": "The identifier of the organization in the selected scheme."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "uri": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                                "format": "uri"
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "scheme": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "legalName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The legally registered name of the organization."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "contactPoint": {
+                            "properties": {
+                                "faxNumber": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "url": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "A web address for the contact point/person.",
+                                                "format": "uri"
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "name": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "email": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The e-mail address of the contact point/person."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "telephone": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "description": "An person, contact point or department to contact in relation to this contracting process."
+                        },
+                        "additionalIdentifiers": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        },
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
                     "type": "object",
                     "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                             "type": [
                                 "string",
                                 "null"
                             ]
                         }
                     },
+                    "title": "Organization",
+                    "description": "An organization."
+                },
+                "enquiryPeriod": {
                     "properties": {
-                        "changes": {
-                            "type": "array",
+                        "endDate": {
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
                                     },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
                                     "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "awardCriteriaDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the award or selection criteria."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender title"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "minValue": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "amendment": {
+                    "properties": {
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
                                         "items": {
-                                            "type": "object",
                                             "properties": {
                                                 "property": {
                                                     "type": "string",
@@ -933,110 +1720,251 @@
                                                     ],
                                                     "description": "The previous value of the changed property, in whatever type the property is."
                                                 }
-                                            }
-                                        }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array"
                                     },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
                                     "releaseID": {
                                         "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
                         },
                         "date": {
-                            "type": "array",
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
                                     },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
                                     },
-                                    "releaseTag": {
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "title": "Amendment Date",
+                                        "description": "The data of this amendment.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         }
                     },
                     "title": "Amendment information"
+                },
+                "numberOfTenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "definition": "The number of entities who submit a tender."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethodDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procurementMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                                "enum": [
+                                    "open",
+                                    "selective",
+                                    "limited",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
+                                "enum": [
+                                    "planned",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    "complete",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "array",
+                                    "null"
+                                ],
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
             },
-            "required": [
-                "id",
-                "awardID"
-            ]
-        },
-        "Implementation": {
+            "patternProperties": {
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
             "type": "object",
-            "description": "Information during the performance / implementation stage of the contract.",
-            "properties": {
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    },
-                    "description": "As milestones are completed, milestone completions should be documented.",
-                    "uniqueItems": true
-                },
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Transaction"
-                    },
-                    "description": "A list of the spending transactions made against this contract",
-                    "uniqueItems": true
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    },
-                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
-                    "uniqueItems": true
-                }
-            },
-            "title": "Implementation"
+            "title": "Tender"
         },
+        "date": {
+            "type": "string",
+            "title": "Release Date",
+            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order.",
+            "format": "date-time"
+        }
+    },
+    "definitions": {
         "Milestone": {
+            "required": [
+                "id"
+            ],
             "type": "object",
             "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
@@ -1053,12 +1981,104 @@
                 }
             },
             "properties": {
-                "status": {
-                    "type": "array",
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
+                },
+                "dateModified": {
                     "items": {
                         "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct.",
+                                "format": "date-time"
+                            },
                             "releaseID": {
                                 "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of the milestone."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "documents": {
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array",
+                    "uniqueItems": true,
+                    "description": "List of documents associated with this milestone."
+                },
+                "dueDate": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The date the milestone is due.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -1073,62 +2093,22 @@
                                     null
                                 ]
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dueDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date the milestone is due."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
                             }
                         }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "List of documents associated with this milestone.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier for this milestone, unique within this block. This field is used to keep track of multiple revisions of a milestone through the compilation from release to record mechanism."
+                    },
+                    "type": "array"
                 },
                 "title": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -1137,94 +2117,164 @@
                                 ],
                                 "description": "Milestone title"
                             },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            }
+        },
+        "Classification": {
+            "properties": {
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The classification code drawn from the selected scheme."
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
+                                "format": "uri"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "scheme": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "description": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "A description of the milestone."
+                                "description": "A textual description or title for the code."
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date the milestone was last reviewed or modified and the status was altered or confirmed to still be correct."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 }
             },
-            "required": [
-                "id"
-            ]
-        },
-        "Amendment": {
             "type": "object",
             "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
                 }
-            },
+            }
+        },
+        "Amendment": {
             "properties": {
-                "changes": {
-                    "type": "array",
+                "rationale": {
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
                             },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
                             "value": {
-                                "title": "Amended fields",
-                                "description": "Comma-seperated list of affected fields.",
-                                "type": "array",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "An explanation for the amendment."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "changes": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
                                 "items": {
-                                    "type": "object",
                                     "properties": {
                                         "property": {
                                             "type": "string",
@@ -1241,383 +2291,120 @@
                                             ],
                                             "description": "The previous value of the changed property, in whatever type the property is."
                                         }
-                                    }
-                                }
+                                    },
+                                    "type": "object"
+                                },
+                                "title": "Amended fields",
+                                "description": "Comma-seperated list of affected fields.",
+                                "type": "array"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "rationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "An explanation for the amendment."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "date": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "title": "Amendment Date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The data of this amendment."
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "title": "Amendment Date",
+                                "description": "The data of this amendment.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "title": "Amendment information"
         },
-        "Identifier": {
-            "type": "object",
-            "patternProperties": {
-                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "properties": {
-                "uri": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "legalName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The legally registered name of the organization."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "scheme": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The identifier of the organization in the selected scheme."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "Address": {
-            "type": "object",
-            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-            "properties": {
-                "postalCode": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The postal code. For example, 94043."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "streetAddress": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "countryName": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The country name. For example, United States."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "locality": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The locality. For example, Mountain View."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "region": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The region. For example, CA."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "patternProperties": {
-                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
         "Budget": {
-            "type": "object",
-            "mergeStrategy": "ocdsVersion",
-            "title": "Budget Information",
-            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
             "properties": {
-                "source": {
-                    "format": "uri",
-                    "title": "Data Source",
-                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
-                },
                 "id": {
                     "type": [
                         "string",
                         "integer",
                         "null"
                     ],
-                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                    "mergeStrategy": "ocdsVersion"
+                    "mergeStrategy": "ocdsVersion",
+                    "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
                 },
-                "amount": {
-                    "$ref": "#/definitions/Value",
-                    "description": "The value of the budget line item."
-                },
-                "uri": {
-                    "format": "uri",
-                    "title": "Linked budget information",
-                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                "source": {
                     "type": [
                         "string",
                         "null"
                     ],
+                    "format": "uri",
+                    "title": "Data Source",
+                    "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
                     "mergeStrategy": "ocdsVersion"
                 },
+                "project": {
+                    "mergeStrategy": "ocdsVersion",
+                    "title": "Project Title",
+                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "description": {
+                    "mergeStrategy": "ocdsVersion",
                     "title": "Budget Source",
                     "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
                     "type": [
                         "string",
                         "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
+                    ]
                 },
                 "projectID": {
+                    "mergeStrategy": "ocdsVersion",
                     "title": "Project Identifier",
                     "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
                     "type": [
                         "string",
                         "integer",
                         "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
+                    ]
                 },
-                "project": {
-                    "title": "Project Title",
-                    "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                "amount": {
+                    "$ref": "#/definitions/Value",
+                    "description": "The value of the budget line item."
+                },
+                "uri": {
+                    "mergeStrategy": "ocdsVersion",
+                    "format": "uri",
+                    "title": "Linked budget information",
+                    "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
                     "type": [
                         "string",
                         "null"
-                    ],
-                    "mergeStrategy": "ocdsVersion"
+                    ]
                 }
             },
             "patternProperties": {
@@ -1639,663 +2426,63 @@
                         "null"
                     ]
                 }
-            }
-        },
-        "Item": {
-            "type": "object",
-            "description": "A good, service, or work to be contracted.",
-            "properties": {
-                "additionalClassifications": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Classification"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "unit": {
-                    "type": "object",
-                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit.",
-                    "properties": {
-                        "value": {
-                            "type": "object",
-                            "properties": {
-                                "amount": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "minimum": 0,
-                                                "type": [
-                                                    "number",
-                                                    "null"
-                                                ],
-                                                "description": "Amount as a number."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "currency": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The currency in 3-letter ISO 4217 format."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Name of the unit"
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "quantity": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "minimum": 0,
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The number of units required"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
-                },
-                "classification": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "description": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "A textual description or title for the code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The classification code drawn from the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of the goods, services to be provided."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
             },
+            "mergeStrategy": "ocdsVersion",
+            "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+            "type": "object",
+            "title": "Budget Information"
+        },
+        "Award": {
             "required": [
                 "id"
             ],
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "Document": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Document",
-            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
             "properties": {
-                "url": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "language": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "format": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documentType": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
                 "id": {
                     "type": [
                         "string",
                         "integer"
                     ],
-                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
+                    "title": "Award ID",
+                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details."
                 },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The document title."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "dateModified": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "Date that the document was last modified"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "datePublished": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Award": {
-            "type": "object",
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Award",
-            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "properties": {
-                "value": {
-                    "type": "object",
+                "amendment": {
                     "properties": {
-                        "amount": {
-                            "type": "array",
+                        "rationale": {
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
                                     },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
                                     },
                                     "value": {
                                         "type": [
                                             "string",
                                             "null"
                                         ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
                                     },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
                                     },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award Status",
-                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
-                                "enum": [
-                                    "pending",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful"
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
                                     "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
                                         "items": {
-                                            "type": "object",
                                             "properties": {
                                                 "property": {
                                                     "type": "string",
@@ -2312,118 +2499,121 @@
                                                     ],
                                                     "description": "The previous value of the changed property, in whatever type the property is."
                                                 }
-                                            }
-                                        }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array"
                                     },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
                                     "releaseID": {
                                         "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
                         },
                         "date": {
-                            "type": "array",
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
                                     },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
                                     },
-                                    "releaseTag": {
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "title": "Amendment Date",
+                                        "description": "The data of this amendment.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         }
                     },
                     "title": "Amendment information"
                 },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Document"
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
                     },
-                    "description": "All documents and attachments related to the award, including any notices.",
-                    "uniqueItems": true
+                    "type": "object"
                 },
-                "id": {
-                    "title": "Award ID",
-                    "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.",
-                    "type": [
-                        "string",
-                        "integer"
-                    ]
-                },
-                "title": {
-                    "type": "array",
+                "description": {
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Award title"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
                             },
                             "value": {
                                 "type": [
@@ -2432,440 +2622,911 @@
                                 ],
                                 "description": "Award description"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "suppliers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
                             "releaseID": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "date": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Award date",
-                                "format": "date-time",
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The date of the contract award. This is usually the date on which a decision to award was made."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "minItems": 1,
-                    "title": "Items Awarded",
-                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "contractPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
                             }
                         }
                     },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "Period": {
-            "type": "object",
-            "properties": {
-                "endDate": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "date-time",
-                                "description": "The end date for the period."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                    "type": "array"
                 },
-                "startDate": {
+                "documents": {
+                    "uniqueItems": true,
+                    "description": "All documents and attachments related to the award, including any notices.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array"
+                },
+                "items": {
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    },
                     "type": "array",
+                    "description": "The goods and services awarded in this award, broken into line items wherever possible. Items should not be duplicated, but the quantity specified instead.",
+                    "title": "Items Awarded"
+                },
+                "contractPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "status": {
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "format": "date-time",
-                                "description": "The start date for the period."
+                                "title": "Award Status",
+                                "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)",
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Award title"
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "suppliers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "The suppliers awarded this award. If different suppliers have been awarded different items of values, these should be split into separate award blocks."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "date": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "title": "Award date",
+                                "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
             },
-            "title": "Period"
-        },
-        "Classification": {
-            "type": "object",
             "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
                         "null"
                     ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
+            "description": "An award for the given procurement. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
+            "type": "object",
+            "title": "Award"
+        },
+        "Contract": {
+            "required": [
+                "id",
+                "awardID"
+            ],
             "properties": {
-                "uri": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "title": "Contract ID",
+                    "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details."
+                },
+                "period": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "implementation": {
+                    "properties": {
+                        "documents": {
+                            "uniqueItems": true,
+                            "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                            "items": {
+                                "$ref": "#/definitions/Document"
+                            },
+                            "type": "array"
+                        },
+                        "milestones": {
+                            "uniqueItems": true,
+                            "description": "As milestones are completed, milestone completions should be documented.",
+                            "items": {
+                                "$ref": "#/definitions/Milestone"
+                            },
+                            "type": "array"
+                        },
+                        "transactions": {
+                            "uniqueItems": true,
+                            "description": "A list of the spending transactions made against this contract",
+                            "items": {
+                                "$ref": "#/definitions/Transaction"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Implementation",
+                    "description": "Information during the performance / implementation stage of the contract."
+                },
+                "amendment": {
+                    "properties": {
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "title": "Amendment Date",
+                                        "description": "The data of this amendment.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "title": "Amendment information"
+                },
+                "items": {
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    },
                     "type": "array",
+                    "description": "The goods, services, and any intangible outcomes in this contract. Note: If the items are the same as the award do not repeat.",
+                    "title": "Items Contracted"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "awardID": {
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "format": "uri",
-                                "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank."
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "title": "Award ID",
+                                "description": "The award.id against which this contract is being issued."
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "description": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "A textual description or title for the code."
+                                "description": "Contract description"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
-                "scheme": {
-                    "type": "array",
+                "documents": {
+                    "uniqueItems": true,
+                    "description": "All documents and attachments related to the contract, including any notices.",
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array"
                 },
-                "id": {
-                    "type": "array",
+                "status": {
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ],
-                                "description": "The classification code drawn from the selected scheme."
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "title": "Contract Status",
+                                "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)",
+                                "enum": [
+                                    "pending",
+                                    "active",
+                                    "cancelled",
+                                    "terminated",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "dateSigned": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The date the contract was signed. In the case of multiple signatures, the date of the last signature.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Contract title"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
-            }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "description": "Information regarding the signed contract between the buyer and supplier(s).",
+            "type": "object",
+            "title": "Contract"
+        },
+        "Document": {
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local, unique identifier for this document. This field is used to keep track of multiple revisions of a document through the compilation from release to record mechanism."
+                },
+                "dateModified": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Date that the document was last modified",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "language": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specifies the language of the linked document using either two-digit [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), or extended [BCP47 language tags](http://www.w3.org/International/articles/language-tags/). The use of two-letter codes from [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) is strongly recommended unless there is a clear user need for distinguishing the language subtype."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A short description of the document. We recommend descriptions do not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "documentType": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "format": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The format of the document taken from the [IANA Media Types code list](http://www.iana.org/assignments/media-types/), with the addition of one extra value for 'offline/print', used when this document entry is being used to describe the offline publication of a document. Use values from the template column. Links to web pages should be tagged 'text/html'."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The document title."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "datePublished": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The date on which the document was first published. This is particularly important for legally important documents such as notices of a tender.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "url": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": " direct link to the document or attachment. The server providing access to this document should be configured to correctly report the document mime type.",
+                                "format": "uri"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "description": "Links to, or descriptions of, external documents can be attached at various locations within the standard. Documents may be supporting information, formal notices, downloadable forms, or any other kind of resource that should be made public as part of full open contracting.",
+            "type": "object",
+            "title": "Document"
+        },
+        "Implementation": {
+            "properties": {
+                "documents": {
+                    "uniqueItems": true,
+                    "description": "Documents and reports that are part of the implementation phase e.g. audit and evaluation reports.",
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array"
+                },
+                "milestones": {
+                    "uniqueItems": true,
+                    "description": "As milestones are completed, milestone completions should be documented.",
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "type": "array"
+                },
+                "transactions": {
+                    "uniqueItems": true,
+                    "description": "A list of the spending transactions made against this contract",
+                    "items": {
+                        "$ref": "#/definitions/Transaction"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "title": "Implementation",
+            "description": "Information during the performance / implementation stage of the contract."
         },
         "Organization": {
-            "title": "Organization",
-            "description": "An organization.",
             "properties": {
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
                 "address": {
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
                     "properties": {
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
                         "region": {
-                            "type": "array",
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
                                     },
                                     "value": {
                                         "type": [
@@ -2874,17 +3535,111 @@
                                         ],
                                         "description": "The region. For example, CA."
                                     },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "locality": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
                                     },
-                                    "releaseTag": {
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The locality. For example, Mountain View."
+                                    },
+                                    "releaseID": {
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
+                        },
+                        "countryName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The country name. For example, United States."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "streetAddress": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "postalCode": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The postal code. For example, 94043."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
                         }
                     },
+                    "type": "object",
                     "patternProperties": {
                         "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                             "type": [
@@ -2892,233 +3647,20 @@
                                 "null"
                             ]
                         }
-                    }
-                },
-                "contactPoint": {
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "properties": {
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
                     },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
+                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
                 },
                 "identifier": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
                     "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
                         "id": {
-                            "type": "array",
                             "items": {
                                 "properties": {
-                                    "releaseID": {
+                                    "releaseTag": {
                                         "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
                                     },
                                     "value": {
                                         "type": [
@@ -3128,24 +3670,266 @@
                                         ],
                                         "description": "The identifier of the organization in the selected scheme."
                                     },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
                                     "releaseDate": {
                                         "type": "string",
                                         "format": "date-time"
                                     },
-                                    "releaseTag": {
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         }
                     }
                 },
-                "name": {
-                    "type": "array",
+                "contactPoint": {
+                    "properties": {
+                        "faxNumber": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "url": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A web address for the contact point/person.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "email": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The e-mail address of the contact point/person."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "telephone": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "description": "An person, contact point or department to contact in relation to this contracting process."
+                },
+                "additionalIdentifiers": {
                     "items": {
                         "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Identifier"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
+                            },
                             "releaseID": {
                                 "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -3154,15 +3938,12 @@
                                 ],
                                 "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 }
             },
             "type": "object",
@@ -3173,90 +3954,2300 @@
                         "null"
                     ]
                 }
+            },
+            "title": "Organization",
+            "description": "An organization."
+        },
+        "Item": {
+            "required": [
+                "id"
+            ],
+            "type": "object",
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A local identifier to reference and merge the items by. Must be unique within a given array of items."
+                },
+                "additionalClassifications": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Classification"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "classification": {
+                    "properties": {
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The classification code drawn from the selected scheme."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A URI to identify the code. In the event individual URIs are not available for items in the identifier scheme this value should be left blank.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme) wherever possible."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "description": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A textual description or title for the code."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of the goods, services to be provided."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "unit": {
+                    "properties": {
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Name of the unit"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "value": {
+                            "properties": {
+                                "amount": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ],
+                                                "description": "Amount as a number.",
+                                                "minimum": 0
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "currency": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The currency in 3-letter ISO 4217 format."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "description": "Description of the unit which the good comes in e.g. hours, kilograms. Made up of a unit name, and the value of a single unit."
+                },
+                "quantity": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The number of units required",
+                                "minimum": 0
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "description": "A good, service, or work to be contracted."
+        },
+        "Address": {
+            "properties": {
+                "region": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The region. For example, CA."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "locality": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The locality. For example, Mountain View."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "countryName": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The country name. For example, United States."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "streetAddress": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "postalCode": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The postal code. For example, 94043."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
+        },
+        "Identifier": {
+            "properties": {
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "The identifier of the organization in the selected scheme."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                "format": "uri"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "scheme": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "legalName": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The legally registered name of the organization."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "patternProperties": {
+                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
             }
         },
-        "ContactPoint": {
+        "Transaction": {
+            "required": [
+                "id"
+            ],
             "type": "object",
-            "description": "An person, contact point or department to contact in relation to this contracting process.",
             "properties": {
-                "telephone": {
-                    "type": "array",
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "description": "A unique identifier for this transaction. This identifier should be possible to cross-reference against the provided data source. For the budget data package this is the id, for IATI, the transaction reference."
+                },
+                "source": {
                     "items": {
                         "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "title": "Data Source",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Used to point either to a corresponding Budget Data Package, IATI file, or machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
+                                "format": "uri"
+                            },
                             "releaseID": {
                                 "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "providerOrganization": {
+                    "properties": {
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                },
+                "amount": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "title": "Linked spending information",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A URI pointing directly to a machine-readable record about this spending transaction.",
+                                "format": "uri"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "date": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                "description": "The date of the transaction",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "receiverOrganization": {
+                    "properties": {
+                        "id": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "integer",
+                                            "null"
+                                        ],
+                                        "description": "The identifier of the organization in the selected scheme."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "uri": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                        "format": "uri"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "scheme": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "legalName": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The legally registered name of the organization."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            },
+            "title": "Transaction Information",
+            "description": "A spending transaction related to the contracting process. Draws upon the data models of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md) and the [International Aid Transpareny Initiative](http://iatistandard.org/activity-standard/iati-activities/iati-activity/transaction/) and should be used to cross-reference to more detailed information held using a Budget Data Package, IATI file, or to provide enough information to allow a user to manually or automatically cross-reference with some other published source of transactional spending data."
+        },
+        "Period": {
+            "properties": {
+                "endDate": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "email": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "The e-mail address of the contact point/person."
+                                "description": "The end date for the period.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "startDate": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                "description": "The start date for the period.",
+                                "format": "date-time"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "title": "Period"
+        },
+        "Tender": {
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "title": "Tender ID",
+                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender."
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
+                "procurementMethodRationale": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "eligibilityCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "A description of any eligibility criteria for potential suppliers."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "items": {
+                    "uniqueItems": true,
+                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
+                    "items": {
+                        "$ref": "#/definitions/Item"
+                    },
+                    "type": "array",
+                    "title": "Items to be procured"
+                },
+                "documents": {
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array",
+                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include."
+                },
+                "hasEnquiries": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardCriteria": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "awardPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "milestones": {
+                    "items": {
+                        "$ref": "#/definitions/Milestone"
+                    },
+                    "type": "array",
+                    "description": "A list of milestones associated with the tender."
+                },
+                "description": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender description"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "tenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "$ref": "#/definitions/Organization"
+                                },
+                                "type": "array",
+                                "uniqueItems": true,
+                                "description": "All entities who submit a tender."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procuringEntity": {
+                    "properties": {
+                        "address": {
+                            "properties": {
+                                "region": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The region. For example, CA."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "locality": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The locality. For example, Mountain View."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "countryName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The country name. For example, United States."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "streetAddress": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "postalCode": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The postal code. For example, 94043."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process."
+                        },
+                        "identifier": {
+                            "properties": {
+                                "id": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "integer",
+                                                    "null"
+                                                ],
+                                                "description": "The identifier of the organization in the selected scheme."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "uri": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point.",
+                                                "format": "uri"
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "scheme": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "legalName": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The legally registered name of the organization."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            }
+                        },
+                        "contactPoint": {
+                            "properties": {
+                                "faxNumber": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "url": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "A web address for the contact point/person.",
+                                                "format": "uri"
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "name": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "email": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The e-mail address of the contact point/person."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                },
+                                "telephone": {
+                                    "items": {
+                                        "properties": {
+                                            "releaseTag": {
+                                                "type": "string"
+                                            },
+                                            "releaseDate": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            },
+                                            "value": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ],
+                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                                            },
+                                            "releaseID": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "patternProperties": {
+                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                }
+                            },
+                            "description": "An person, contact point or department to contact in relation to this contracting process."
+                        },
+                        "additionalIdentifiers": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "items": {
+                                            "$ref": "#/definitions/Identifier"
+                                        },
+                                        "type": "array",
+                                        "uniqueItems": true,
+                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "name": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "title": "Organization",
+                    "description": "An organization."
+                },
+                "enquiryPeriod": {
+                    "properties": {
+                        "endDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The end date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "startDate": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The start date for the period.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "title": "Period"
+                },
+                "awardCriteriaDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the award or selection criteria."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Tender title"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "minValue": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "value": {
+                    "properties": {
+                        "amount": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ],
+                                        "description": "Amount as a number.",
+                                        "minimum": 0
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "currency": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "The currency in 3-letter ISO 4217 format."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object"
+                },
+                "amendment": {
+                    "properties": {
+                        "rationale": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "An explanation for the amendment."
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "changes": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "items": {
+                                            "properties": {
+                                                "property": {
+                                                    "type": "string",
+                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
+                                                },
+                                                "former_value": {
+                                                    "type": [
+                                                        "string",
+                                                        "number",
+                                                        "integer",
+                                                        "array",
+                                                        "object",
+                                                        "null"
+                                                    ],
+                                                    "description": "The previous value of the changed property, in whatever type the property is."
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "title": "Amended fields",
+                                        "description": "Comma-seperated list of affected fields.",
+                                        "type": "array"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        },
+                        "date": {
+                            "items": {
+                                "properties": {
+                                    "releaseTag": {
+                                        "type": "string"
+                                    },
+                                    "releaseDate": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "title": "Amendment Date",
+                                        "description": "The data of this amendment.",
+                                        "format": "date-time"
+                                    },
+                                    "releaseID": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "patternProperties": {
+                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "title": "Amendment information"
+                },
+                "numberOfTenderers": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "definition": "The number of entities who submit a tender."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethodDetails": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "procurementMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
+                                "enum": [
+                                    "open",
+                                    "selective",
+                                    "limited",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "status": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "title": "Tender Status",
+                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
+                                "enum": [
+                                    "planned",
+                                    "active",
+                                    "cancelled",
+                                    "unsuccessful",
+                                    "complete",
+                                    null
+                                ]
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "submissionMethod": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "array",
+                                    "null"
+                                ],
+                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
+            "type": "object",
+            "title": "Tender"
+        },
+        "Value": {
+            "properties": {
+                "amount": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "number",
+                                    "null"
+                                ],
+                                "description": "Amount as a number.",
+                                "minimum": 0
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "currency": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The currency in 3-letter ISO 4217 format."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "ContactPoint": {
+            "properties": {
                 "faxNumber": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -3265,42 +6256,112 @@
                                 ],
                                 "description": "The fax number of the contact point/person. This should include the international dialling code."
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "url": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
                                     "string",
                                     "null"
                                 ],
-                                "format": "uri",
-                                "description": "A web address for the contact point/person."
+                                "description": "A web address for the contact point/person.",
+                                "format": "uri"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
+                            },
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "email": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The e-mail address of the contact point/person."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "telephone": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
                 }
             },
+            "type": "object",
             "patternProperties": {
                 "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
@@ -3308,2561 +6369,20 @@
                         "null"
                     ]
                 }
-            }
-        },
-        "Tender": {
-            "type": "object",
-            "patternProperties": {
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
             },
-            "title": "Tender",
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "properties": {
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "title": "Items to be procured",
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "minValue": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procuringEntity": {
-                    "title": "Organization",
-                    "description": "An organization.",
-                    "properties": {
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true,
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "properties": {
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "properties": {
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "properties": {
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender.",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    }
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        }
-    },
-    "properties": {
-        "language": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Release language",
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "description": "Specifies the default language of the data using either two-digit ISO 639-1, or extended BCP47 language tags. The use of two-letter codes from ISO 639-1 is strongly recommended.",
-                        "default": "en"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
-                }
-            }
+            "description": "An person, contact point or department to contact in relation to this contracting process."
         },
-        "tender": {
-            "type": "object",
-            "patternProperties": {
-                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "Tender",
-            "description": "Data regarding tender process - publicly inviting prospective contractors to submit bids for evaluation and selecting a winner or winners.",
-            "properties": {
-                "value": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender ID",
-                                "description": "An identifier for this tender process. This may be the same as the ocid, or may be drawn from an internally held identifier for this tender.",
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "status": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "title": "Tender Status",
-                                "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)",
-                                "enum": [
-                                    "planned",
-                                    "active",
-                                    "cancelled",
-                                    "unsuccessful",
-                                    "complete",
-                                    null
-                                ],
-                                "type": [
-                                    "string",
-                                    "null"
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "All entities who submit a tender.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Organization"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardCriteriaDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the award or selection criteria."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "numberOfTenderers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ],
-                                "definition": "The number of entities who submit a tender."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enquiryPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "submissionMethodDetails": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Any detailed or further information on the submission method. This may include the address, e-mail address or online service to which bids should be submitted, and any special requirements to be followed for submissions."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procurementMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify tendering method against the [method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#method) as per [GPA definitions](http://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm) of Open, Selective, Limited",
-                                "enum": [
-                                    "open",
-                                    "selective",
-                                    "limited",
-                                    null
-                                ]
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "items": {
-                    "type": "array",
-                    "title": "Items to be procured",
-                    "description": "The goods and services to be purchased, broken into line items wherever possible. Items should not be duplicated, but a quantity of 2 specified instead.",
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/Item"
-                    }
-                },
-                "description": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender description"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "amendment": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "changes": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amended fields",
-                                        "description": "Comma-seperated list of affected fields.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "property": {
-                                                    "type": "string",
-                                                    "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. "
-                                                },
-                                                "former_value": {
-                                                    "type": [
-                                                        "string",
-                                                        "number",
-                                                        "integer",
-                                                        "array",
-                                                        "object",
-                                                        "null"
-                                                    ],
-                                                    "description": "The previous value of the changed property, in whatever type the property is."
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "rationale": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "An explanation for the amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "date": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "title": "Amendment Date",
-                                        "format": "date-time",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The data of this amendment."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Amendment information"
-                },
-                "hasEnquiries": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ],
-                                "description": "A Yes/No field to indicate whether enquiries were part of tender process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "eligibilityCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "A description of any eligibility criteria for potential suppliers."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "awardPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                },
-                "minValue": {
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "minimum": 0,
-                                        "type": [
-                                            "number",
-                                            "null"
-                                        ],
-                                        "description": "Amount as a number."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "currency": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The currency in 3-letter ISO 4217 format."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "awardCriteria": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "procuringEntity": {
-                    "title": "Organization",
-                    "description": "An organization.",
-                    "properties": {
-                        "additionalIdentifiers": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": "array",
-                                        "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                        "uniqueItems": true,
-                                        "items": {
-                                            "$ref": "#/definitions/Identifier"
-                                        }
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "address": {
-                            "type": "object",
-                            "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                            "properties": {
-                                "postalCode": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The postal code. For example, 94043."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "streetAddress": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "countryName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The country name. For example, United States."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "locality": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The locality. For example, Mountain View."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "region": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The region. For example, CA."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "contactPoint": {
-                            "type": "object",
-                            "description": "An person, contact point or department to contact in relation to this contracting process.",
-                            "properties": {
-                                "telephone": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "email": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The e-mail address of the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "name": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "faxNumber": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "url": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A web address for the contact point/person."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "patternProperties": {
-                                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "identifier": {
-                            "type": "object",
-                            "patternProperties": {
-                                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                }
-                            },
-                            "properties": {
-                                "uri": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "format": "uri",
-                                                "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "legalName": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "The legally registered name of the organization."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "scheme": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ],
-                                                "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "id": {
-                                    "type": "array",
-                                    "items": {
-                                        "properties": {
-                                            "releaseID": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": [
-                                                    "string",
-                                                    "integer",
-                                                    "null"
-                                                ],
-                                                "description": "The identifier of the organization in the selected scheme."
-                                            },
-                                            "releaseDate": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "releaseTag": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "type": "object",
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "milestones": {
-                    "type": "array",
-                    "description": "A list of milestones associated with the tender.",
-                    "items": {
-                        "$ref": "#/definitions/Milestone"
-                    }
-                },
-                "procurementMethodRationale": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Rationale of procurement method, especially in the case of Limited tendering."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "title": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "Tender title"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "submissionMethod": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "array",
-                                    "null"
-                                ],
-                                "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "tenderPeriod": {
-                    "type": "object",
-                    "properties": {
-                        "endDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The end date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "startDate": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "date-time",
-                                        "description": "The start date for the period."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "title": "Period"
-                }
-            },
-            "required": [
-                "id"
-            ]
-        },
-        "contracts": {
-            "type": "array",
-            "title": "Contracts",
-            "description": "Information from the contract creation phase of the procurement process.",
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/Contract"
-            }
-        },
-        "planning": {
-            "title": "Planning",
-            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender",
+        "Planning": {
             "properties": {
                 "rationale": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
+                            "releaseTag": {
                                 "type": "string"
+                            },
+                            "releaseDate": {
+                                "type": "string",
+                                "format": "date-time"
                             },
                             "value": {
                                 "type": [
@@ -5871,95 +6391,85 @@
                                 ],
                                 "description": "The rationale for the procurement provided in free text. More detail can be provided in an attached document."
                             },
+                            "releaseID": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "budget": {
+                    "items": {
+                        "properties": {
+                            "releaseTag": {
+                                "type": "string"
+                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
                             },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "documents": {
-                    "type": "array",
-                    "description": "A list of documents related to the planning process.",
-                    "items": {
-                        "$ref": "#/definitions/Document"
-                    }
-                },
-                "budget": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "value": {
-                                "type": "object",
-                                "title": "Budget Information",
-                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
                                 "properties": {
-                                    "source": {
-                                        "format": "uri",
-                                        "title": "Data Source",
-                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
-                                    },
                                     "id": {
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
                                         ],
-                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source.",
-                                        "mergeStrategy": "ocdsVersion"
+                                        "mergeStrategy": "ocdsVersion",
+                                        "description": "An identifier for the budget line item which provides funds for this contracting process. This identifier should be possible to cross-reference against the provided data source."
                                     },
-                                    "amount": {
-                                        "$ref": "#/definitions/Value",
-                                        "description": "The value of the budget line item."
-                                    },
-                                    "uri": {
-                                        "format": "uri",
-                                        "title": "Linked budget information",
-                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
+                                    "source": {
                                         "type": [
                                             "string",
                                             "null"
                                         ],
+                                        "format": "uri",
+                                        "title": "Data Source",
+                                        "description": "Used to point either to a corresponding Budget Data Package, or to a machine or human-readable source where users can find further information on the budget line item identifiers, or project identifiers, provided here.",
                                         "mergeStrategy": "ocdsVersion"
                                     },
+                                    "project": {
+                                        "mergeStrategy": "ocdsVersion",
+                                        "title": "Project Title",
+                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
                                     "description": {
+                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Budget Source",
                                         "description": "A short free text description of the budget source. May be used to provide the title of the budget line, or the programme used to fund this project.",
                                         "type": [
                                             "string",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     },
                                     "projectID": {
+                                        "mergeStrategy": "ocdsVersion",
                                         "title": "Project Identifier",
                                         "description": "An external identifier for the project that this contracting process forms part of, or is funded via (if applicable). Some organizations maintain a registry of projects, and the data should use the identifier from the relevant registry of projects.",
                                         "type": [
                                             "string",
                                             "integer",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     },
-                                    "project": {
-                                        "title": "Project Title",
-                                        "description": "The name of the project that through which this contracting process is funded (if applicable). Some organizations maintain a registry of projects, and the data should use the name by which the project is known in that registry. No translation option is offered for this string, as translated values can be provided in third-party data, linked from the data source above.",
+                                    "amount": {
+                                        "$ref": "#/definitions/Value",
+                                        "description": "The value of the budget line item."
+                                    },
+                                    "uri": {
+                                        "mergeStrategy": "ocdsVersion",
+                                        "format": "uri",
+                                        "title": "Linked budget information",
+                                        "description": "A URI pointing directly to a machine-readable record about the related budget or projects for this contracting process.",
                                         "type": [
                                             "string",
                                             "null"
-                                        ],
-                                        "mergeStrategy": "ocdsVersion"
+                                        ]
                                     }
                                 },
                                 "patternProperties": {
@@ -5981,17 +6491,24 @@
                                             "null"
                                         ]
                                     }
-                                }
+                                },
+                                "description": "This section contain information about the budget line, and associated projects, through which this contracting process is funded. It draws upon data model of the [Budget Data Package](https://github.com/openspending/budget-data-package/blob/master/specification.md), and should be used to cross-reference to more detailed information held using a Budget Data Package, or, where no linked Budget Data Package is available, to provide enough information to allow a user to manually or automatically cross-reference with another published source of budget and project information.",
+                                "type": "object",
+                                "title": "Budget Information"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
+                            "releaseID": {
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "documents": {
+                    "items": {
+                        "$ref": "#/definitions/Document"
+                    },
+                    "type": "array",
+                    "description": "A list of documents related to the planning process."
                 }
             },
             "type": "object",
@@ -6002,534 +6519,19 @@
                         "null"
                     ]
                 }
-            }
-        },
-        "initiationType": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "title": "Initiation type",
-                        "description": "String specifying the type of initiation process used for this contract, taken from the [initiationType](http://standard.open-contracting.org/latest/en/schema/codelists/#initiation-type) codelist. Currently only tender is supported.",
-                        "enum": [
-                            "tender"
-                        ],
-                        "type": "string"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "buyer": {
-            "title": "Organization",
-            "description": "An organization.",
-            "properties": {
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "array",
-                                "description": "A list of additional / supplemental identifiers for the organization, using the [organization identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
-                                "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/Identifier"
-                                }
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "address": {
-                    "type": "object",
-                    "description": "An address. This may be the legally registered address of the organization, or may be a correspondence address for this particular contracting process.",
-                    "properties": {
-                        "postalCode": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The postal code. For example, 94043."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "streetAddress": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The street address. For example, 1600 Amphitheatre Pkwy."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "countryName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The country name. For example, United States."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "locality": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The locality. For example, Mountain View."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "region": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The region. For example, CA."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "contactPoint": {
-                    "type": "object",
-                    "description": "An person, contact point or department to contact in relation to this contracting process.",
-                    "properties": {
-                        "telephone": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The telephone number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "email": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The e-mail address of the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "name": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The name of the contact person, department, or contact point, for correspondence relating to this contracting process."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "faxNumber": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The fax number of the contact point/person. This should include the international dialling code."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "url": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A web address for the contact point/person."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "identifier": {
-                    "type": "object",
-                    "patternProperties": {
-                        "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "properties": {
-                        "uri": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "format": "uri",
-                                        "description": "A URI to identify the organization, such as those provided by [Open Corporates](http://www.opencorporates.com) or some other relevant URI provider. This is not for listing the website of the organization: that can be done through the url field of the Organization contact point."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "legalName": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "The legally registered name of the organization."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "scheme": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Organization identifiers be drawn from an existing identification scheme. This field is used to indicate the scheme or codelist in which the identifier will be found. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "id": {
-                            "type": "array",
-                            "items": {
-                                "properties": {
-                                    "releaseID": {
-                                        "type": "string"
-                                    },
-                                    "value": {
-                                        "type": [
-                                            "string",
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "The identifier of the organization in the selected scheme."
-                                    },
-                                    "releaseDate": {
-                                        "type": "string",
-                                        "format": "date-time"
-                                    },
-                                    "releaseTag": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "name": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "null"
-                                ],
-                                "description": "The common name of the organization. The ID property provides an space for the formal legal name, and so this may either repeat that value, or could provide the common name by which this organization is known. This field could also include details of the department or sub-unit involved in this contracting process."
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
             },
-            "type": "object",
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "awards": {
-            "type": "array",
-            "title": "Awards",
-            "description": "Information from the award phase of the contracting process. There may be more than one award per contracting process e.g. because the contract is split amongst different providers, or because it is a standing offer.",
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/Award"
-            }
-        },
-        "id": {
-            "title": "Release ID",
-            "description": "A unique identifier that identifies this release. A releaseID must be unique within a release-package and must not contain the # character.",
-            "type": "string"
-        },
-        "date": {
-            "title": "Release Date",
-            "format": "date-time",
-            "type": "string",
-            "description": "The date this information is released, it may well be the same as the parent publishedDate, it must not be later than the publishedDate from the parent package. It is used to determine merge order."
-        },
-        "tag": {
-            "title": "Release Tag",
-            "description": "A value from the [releaseTag codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#release-tag) that identifies the nature of the release being made. Tags may be used to filter release, or, in future, for for advanced validation when certain kinds of releases should contain certain fields.",
-            "type": "array",
-            "items": {
-                "type": "string",
-                "enum": [
-                    "planning",
-                    "tender",
-                    "tenderAmendment",
-                    "tenderUpdate",
-                    "tenderCancellation",
-                    "award",
-                    "awardUpdate",
-                    "awardCancellation",
-                    "contract",
-                    "contractUpdate",
-                    "contractAmendment",
-                    "implementation",
-                    "implementationUpdate",
-                    "contractTermination",
-                    "compiled"
-                ]
-            }
-        },
-        "ocid": {
-            "title": "Open Contracting ID",
-            "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/)",
-            "type": "string"
+            "title": "Planning",
+            "description": "Information from the planning phase of the contracting process. Note that many other fields may be filled in a planning release, in the appropriate fields in other schema sections, these would likely be estimates at this stage e.g. totalValue in tender"
         }
     },
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
     "required": [
         "ocid",
         "id",
         "date",
         "tag",
         "initiationType"
-    ]
+    ],
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Schema for a compiled, versioned Open Contracting Release."
 }


### PR DESCRIPTION
This pull request batches several of the schema changes for 1.0.1 to make them easier to review together. A high level description of these changes can be found in [issue 311](https://github.com/open-contracting/standard/issues/311).

This pull request excludes changes to the versioned schema in 1.0.1, which are in a separate pull request at  https://github.com/open-contracting/standard/pull/304, as the diff is larger and easier to review separately.

<!---
@huboard:{"order":75.0,"milestone_order":305,"custom_state":"archived"}
-->
