### PR TITLE
There is no statusDescription field in the standard

### DIFF
--- a/standard/schema/codelists/awardStatus.csv
+++ b/standard/schema/codelists/awardStatus.csv
@@ -2,4 +2,4 @@ Category,Code,Title_en,Description_en,Source
 ,pending,Pending,"This award has been proposed, but is not yet in force. This may be due to a cooling off period, or some other process.",
 ,active,Active,"This award has been made, and is currently in force.",
 ,cancelled,Cancelled,This award has been cancelled.,
-,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers). The reason that the award did not suceed will be given in the statusDescription field.",
+,unsuccessful,Unsuccessful,"This award could not be successfully made. If items or supplier details are included within the award section, then these narrow the scope of the unsuccessful award (i.e. the award of noted items, or an award to the noted supplier, was unsuccessful, but there may be other successful awards for different items listed in the tender, or to different suppliers).",


### PR DESCRIPTION
This is a copy of https://github.com/open-contracting/standard/pull/257 against the new 1.0-dev branch (as master has now been removed).

> It would be useful to have an awardStatusDetails (as free text) to add information about why an award was unsuccessful or anything related with the status but so far we don't have it.

As noted in https://github.com/open-contracting/standard/pull/257#issuecomment-189231743 we're planning to make this change to this codelist description, to remove the reference to the field that doesn't exist.

There's also an issue about actually adding the new field at https://github.com/open-contracting/standard/issues/248

<!---
@huboard:{"order":37.5,"milestone_order":307,"custom_state":"archived"}
-->
