### PR TITLE
Make make_validation_schema simpler and useful for extensions

### DIFF
--- a/standard/docs/en/schema/merging.md
+++ b/standard/docs/en/schema/merging.md
@@ -124,14 +124,16 @@ A reference implementation of the merge routine in python [is available on GitHu
 
 There are some situations in which it is important to be able to see how data about a contracting process has changed over time. For example, to identify how contract values have altered, or milestones moved through stages of implementation. 
 
-The versioned release schema provides a model for representing this data.
+The [versioned release validation schema](../../versioned-release-validation-schema.json) provides a model for representing this data.
 
-In a versioned release, instead of over-writing past values when combining multiple releases, each field becomes an array of objects, indicating the:
+In a versioned release, instead of over-writing past values when combining multiple releases, each field (with the exception of the ```id``` property of objects within an array) becomes an array of objects, indicating the:
 
 * The date, id and tag of the releases where a field-value pair was first encountered;
 * The value of the field-value pair at that point;
 
-As a result, the history of any field can be easily read from the data structure. 
+As a result, the history of any field can be easily read from the data structure.
+
+The property ```"versionId":true``` is used to explicitly declare the cases where an ```id``` field **should** be versioned (i.e. within an object that is not within an array). 
 
 ### Example
 
@@ -140,8 +142,16 @@ As a result, the history of any field can be easily read from the data structure
 .. jsoninclude:: docs/en/examples/merging/versioned.json
    :jsonpointer: /records/0/versionedRelease/tender/value
    :expand: value, amount
-   :title: versioned
+   :title: versioned_extract
+   
+```
 
+```eval_rst
 
+.. jsoninclude:: docs/en/examples/merging/versioned.json
+   :jsonpointer: 
+   :expand: 
+   :title: full_versioned_file
+   
 ```
 

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -188,7 +188,8 @@
             "string",
             "integer"
           ],
-          "minLength": 1
+          "minLength": 1,
+          "versionId": true
         },
         "title": {
           "title": "Tender title",
@@ -1401,7 +1402,8 @@
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "versionId": true
             },
             "name": {
               "title": "Name",

--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -3,26 +3,26 @@ import json
 from collections import OrderedDict
 import copy
 
-version_template = OrderedDict({
-    "type": "array",
-    "items": {
-        "properties": {
-            "releaseDate": {
-                "format": "date-time",
+version_template = OrderedDict([
+    ("type", "array"),
+    ("items", OrderedDict([
+        ("properties", OrderedDict([
+            ("releaseDate", OrderedDict([
+                ("format", "date-time"),
+                ("type", "string")
+            ])),
+            ("releaseID", {
                 "type": "string"
-            },
-            "releaseID": {
-                "type": "string"
-            },
-            "value": {
-            },
-            "releaseTag": {
-                "type": "array",
-                "items": {"type": "string"}
-            }
-        }
-   }
-})
+            }),
+            ("value", {
+            }),
+            ("releaseTag", OrderedDict([
+                ("type", "array"),
+                ("items", {"type": "string"})
+            ]))
+        ]))
+   ]))
+])
 
 def add_versions(schema, location=''):
     for key, value in list(schema['properties'].items()):
@@ -38,7 +38,7 @@ def add_versions(schema, location=''):
         if mergeStrategy == 'overwrite':
             continue
         if prop_type == ["string", "null"] and "enum" not in value:
-            new_value = {}
+            new_value = OrderedDict()
             format = value.get('format')
             if format == 'uri':
                 new_value["$ref"] = "#/definitions/StringNullUriVersioned"
@@ -73,12 +73,12 @@ def add_versions(schema, location=''):
 
             
 def add_string_definitions(schema):
-    for item, format in {"StringNullUriVersioned": "uri", 
-                         "StringNullDateTimeVersioned": "date-time",
-                         "StringNullVersioned": None}.items():
+    for item, format in [("StringNullUriVersioned", "uri"), 
+                         ("StringNullDateTimeVersioned", "date-time"),
+                         ("StringNullVersioned", None)]:
         version = copy.deepcopy(version_template)
         version_properties = version["items"]["properties"]
-        version_properties["value"] = {"type": ["string", "null"]}
+        version_properties["value"] = OrderedDict([("type", ["string", "null"])])
         if format:
             version_properties["value"]["format"] = format
         schema['definitions'][item] = version
@@ -98,7 +98,7 @@ def get_versioned_validation_schema(versioned_release):
 
     definitions = versioned_release['definitions']
 
-    new_definitions = {}
+    new_definitions = OrderedDict()
     for key, value in copy.deepcopy(versioned_release['definitions']).items():
         new_definitions[key + 'Unversioned'] = value
 
@@ -118,14 +118,6 @@ def get_versioned_validation_schema(versioned_release):
     add_versions(versioned_release)
 
     versioned_release['properties']["ocid"] = ocid
-
-    ### these can be deleted just here to maintain order as before
-    definitions['IdentifierUnversioned'] = new_definitions["IdentifierUnversioned"]
-    definitions['ClassificationUnversioned'] = new_definitions["ClassificationUnversioned"]
-    definitions['AddressUnversioned'] = new_definitions["AddressUnversioned"]
-    definitions['ContactPointUnversioned'] = new_definitions["ContactPointUnversioned"]
-    definitions['OrganizationUnversioned'] = new_definitions["OrganizationUnversioned"]
-    ### end block that can be deleted
 
     definitions.update(new_definitions)
     add_string_definitions(versioned_release)

--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -29,15 +29,14 @@ def add_versions(schema, location=''):
         prop_type = value.get('type')
         value.pop("title", None)
         value.pop("description", None)
-        value.pop("mergeStrategy", None)
+        mergeStrategy = value.pop("mergeStrategy", None)
         value.pop("mergeOptions", None)
         value.pop("omitWhenMerged", None)
         value.pop("wholeListMerge", None)
         if not prop_type:
             continue
-        if key == 'id':
-            if location not in ("Budget", "Tender", "Classification", "Identifier"):
-                continue
+        if mergeStrategy == 'overwrite':
+            continue
         if prop_type == ["string", "null"] and "enum" not in value:
             new_value = {}
             format = value.get('format')
@@ -51,25 +50,14 @@ def add_versions(schema, location=''):
         elif prop_type == "array":
             version = copy.deepcopy(version_template)
             version_properties = version["items"]["properties"]
-            if key in ('tenderers', 'suppliers'):
-                version_properties["value"] = {"type": "array",
-                                               "items": {"$ref": "#/definitions/OrganizationUnversioned"},
-                                               "uniqueItems": True}
+            if mergeStrategy == 'ocdsVersion':
+                new_value = copy.deepcopy(value)
+                
+                if '$ref' in new_value['items']:
+                    new_value['items']["$ref"] = value['items']['$ref'] + "Unversioned"
+                version_properties["value"] =  new_value
                 schema['properties'][key] = version
-            if key == 'additionalIdentifiers':
-                version_properties["value"] = {"type": "array",
-                                               "items": {"$ref": "#/definitions/IdentifierUnversioned"},
-                                               "uniqueItems": True}
-                schema['properties'][key] = version
-            if key == 'additionalClassifications':
-                version_properties["value"] = {"type": "array",
-                                               "items": {"$ref": "#/definitions/ClassificationUnversioned"},
-                                               "uniqueItems": True}
-                schema['properties'][key] = version
-            if key == 'changes':
-                version_properties["value"] = {"type": "array",
-                                               "items": value["items"]}
-                schema['properties'][key] = version
+
             
         elif prop_type == "object":
             add_versions(value, key)
@@ -95,6 +83,13 @@ def add_string_definitions(schema):
             version_properties["value"]["format"] = format
         schema['definitions'][item] = version
 
+def unversion_refs(schema):
+    for key, value in schema.items():
+        if key == '$ref':
+            schema[key] = value + 'Unversioned' 
+        if isinstance(value, dict):
+            unversion_refs(value)
+
 
 def get_versioned_validation_schema(versioned_release):
     versioned_release["id"] = "http://standard.open-contracting.org/schema/1__0__2/versioned-release-validation-schema.json"  # nopep8
@@ -102,22 +97,13 @@ def get_versioned_validation_schema(versioned_release):
     versioned_release["title"] = "Schema for a compiled, versioned Open Contracting Release."  # nopep8
 
     definitions = versioned_release['definitions']
-    for key, value in definitions.items():
-        value.pop("title", None)
-        value.pop("description", None)
-        for prop_value in value['properties'].values():
-            prop_value.pop("mergeStrategy", None)
-            prop_value.pop("mergeOptions", None)
-            prop_value.pop("title", None)
-            prop_value.pop("description", None)
-            prop_value.pop("omitWhenMerged", None)
-            prop_value.pop("wholeListMerge", None)
 
-    OrganizationUnversioned = copy.deepcopy(definitions['Organization'])
-    IdentifierUnversioned = copy.deepcopy(definitions['Identifier'])
-    ClassificationUnversioned = copy.deepcopy(definitions['Classification'])
-    AddressUnversioned = copy.deepcopy(definitions['Address'])
-    ContactPointUnversioned = copy.deepcopy(definitions['ContactPoint'])
+    new_definitions = {}
+    for key, value in copy.deepcopy(versioned_release['definitions']).items():
+        new_definitions[key + 'Unversioned'] = value
+
+    unversion_refs(new_definitions)
+
 
     ocid = versioned_release['properties'].pop("ocid")
     versioned_release['properties'].pop("date")
@@ -129,21 +115,31 @@ def get_versioned_validation_schema(versioned_release):
         "initiationType"
     ]
 
-    #types_count = Counter()
-    #get_types(versioned_release, types_count)
     add_versions(versioned_release)
 
     versioned_release['properties']["ocid"] = ocid
-    definitions['IdentifierUnversioned'] = IdentifierUnversioned
-    definitions['ClassificationUnversioned'] = ClassificationUnversioned
-    definitions['AddressUnversioned'] = AddressUnversioned
-    definitions['ContactPointUnversioned'] = ContactPointUnversioned
-    OrganizationUnversioned["properties"]["identifier"]["$ref"] = "#/definitions/IdentifierUnversioned"
-    OrganizationUnversioned["properties"]["additionalIdentifiers"]["items"]["$ref"] = "#/definitions/IdentifierUnversioned"
-    OrganizationUnversioned["properties"]["address"]["$ref"] = "#/definitions/AddressUnversioned"
-    OrganizationUnversioned["properties"]["contactPoint"]["$ref"] = "#/definitions/ContactPointUnversioned"
-    definitions['OrganizationUnversioned'] = OrganizationUnversioned
+
+    ### these can be deleted just here to maintain order as before
+    definitions['IdentifierUnversioned'] = new_definitions["IdentifierUnversioned"]
+    definitions['ClassificationUnversioned'] = new_definitions["ClassificationUnversioned"]
+    definitions['AddressUnversioned'] = new_definitions["AddressUnversioned"]
+    definitions['ContactPointUnversioned'] = new_definitions["ContactPointUnversioned"]
+    definitions['OrganizationUnversioned'] = new_definitions["OrganizationUnversioned"]
+    ### end block that can be deleted
+
+    definitions.update(new_definitions)
     add_string_definitions(versioned_release)
+
+    for key, value in definitions.items():
+        value.pop("title", None)
+        value.pop("description", None)
+        if not 'properties' in value:
+            continue
+        for prop_value in value['properties'].values():
+            prop_value.pop("mergeStrategy", None)
+            prop_value.pop("mergeOptions", None)
+            prop_value.pop("title", None)
+            prop_value.pop("description", None)
 
     return versioned_release
 

--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -29,13 +29,12 @@ def add_versions(schema, location=''):
         prop_type = value.get('type')
         value.pop("title", None)
         value.pop("description", None)
-        mergeStrategy = value.pop("mergeStrategy", None)
-        value.pop("mergeOptions", None)
-        value.pop("omitWhenMerged", None)
-        value.pop("wholeListMerge", None)
+        omitWhenMerged = value.pop("omitWhenMerged", None)
+        wholeListMerge = value.pop("wholeListMerge", None)
+        versionId = value.pop("versionId", None)
         if not prop_type:
             continue
-        if mergeStrategy == 'overwrite':
+        if key == 'id' and not versionId:
             continue
         if prop_type == ["string", "null"] and "enum" not in value:
             new_value = OrderedDict()
@@ -50,7 +49,7 @@ def add_versions(schema, location=''):
         elif prop_type == "array":
             version = copy.deepcopy(version_template)
             version_properties = version["items"]["properties"]
-            if mergeStrategy == 'ocdsVersion':
+            if wholeListMerge:
                 new_value = copy.deepcopy(value)
                 
                 if '$ref' in new_value['items']:
@@ -128,10 +127,11 @@ def get_versioned_validation_schema(versioned_release):
         if not 'properties' in value:
             continue
         for prop_value in value['properties'].values():
-            prop_value.pop("mergeStrategy", None)
-            prop_value.pop("mergeOptions", None)
             prop_value.pop("title", None)
             prop_value.pop("description", None)
+            prop_value.pop("omitWhenMerged", None)
+            prop_value.pop("wholeListMerge", None)
+            prop_value.pop("versionId", None)
 
     return versioned_release
 

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -5,8 +5,16 @@
     "type": "object",
     "properties": {
         "initiationType": {
+            "type": "array",
             "items": {
                 "properties": {
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseID": {
+                        "type": "string"
+                    },
                     "value": {
                         "type": "string",
                         "enum": [
@@ -15,22 +23,14 @@
                         "codelist": "initiationType.csv",
                         "openCodelist": false
                     },
-                    "releaseDate": {
-                        "format": "date-time",
-                        "type": "string"
-                    },
-                    "releaseID": {
-                        "type": "string"
-                    },
                     "releaseTag": {
+                        "type": "array",
                         "items": {
                             "type": "string"
-                        },
-                        "type": "array"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
         },
         "parties": {
             "type": "array",
@@ -122,15 +122,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -138,15 +132,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -155,8 +155,16 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -173,22 +181,14 @@
                                 "codelist": "tenderStatus.csv",
                                 "openCodelist": false
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "procuringEntity": {
                     "$ref": "#/definitions/OrganizationReference"
@@ -219,8 +219,16 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "additionalProcurementCategories": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "array",
@@ -235,22 +243,14 @@
                                 "codelist": "extendedProcurementCategory.csv",
                                 "openCodelist": true
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "awardCriteria": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -259,8 +259,16 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "submissionMethod": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "array",
@@ -272,22 +280,14 @@
                                 "codelist": "submissionMethod.csv",
                                 "openCodelist": true
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "submissionMethodDetails": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -299,14 +299,9 @@
                     "$ref": "#/definitions/Period"
                 },
                 "hasEnquiries": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "boolean",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -314,15 +309,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "eligibilityCriteria": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -334,14 +334,9 @@
                     "$ref": "#/definitions/Period"
                 },
                 "numberOfTenderers": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -349,15 +344,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "tenderers": {
                     "type": "array",
@@ -438,15 +438,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -454,15 +448,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -471,8 +471,16 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -488,22 +496,14 @@
                                 "codelist": "awardStatus.csv",
                                 "openCodelist": false
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "date": {
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
@@ -573,15 +573,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -589,26 +583,26 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "awardID": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -616,15 +610,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -633,8 +633,16 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -650,22 +658,14 @@
                                 "codelist": "contractStatus.csv",
                                 "openCodelist": false
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "period": {
                     "$ref": "#/definitions/Period"
@@ -769,15 +769,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -785,22 +779,36 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "type": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -819,22 +827,14 @@
                                 "codelist": "milestoneType.csv",
                                 "opencodelist": true
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -852,8 +852,16 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -869,22 +877,14 @@
                                 "codelist": "milestoneStatus.csv",
                                 "openCodelist": false
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "documents": {
                     "type": "array",
@@ -920,15 +920,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -936,15 +930,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "documentType": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -990,15 +990,9 @@
             "type": "object",
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1006,15 +1000,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1026,15 +1026,9 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "projectID": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1042,15 +1036,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "uri": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -1087,15 +1087,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1103,15 +1097,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "source": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -1160,15 +1160,9 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1176,15 +1170,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "identifier": {
                     "deprecated": {
@@ -1232,13 +1232,9 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1246,15 +1242,19 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "identifier": {
                     "$ref": "#/definitions/Identifier"
@@ -1281,14 +1281,9 @@
                     "openCodelist": true
                 },
                 "details": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "object",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1296,15 +1291,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "object",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 }
             },
             "patternProperties": {
@@ -1323,15 +1323,9 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1339,15 +1333,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1363,14 +1363,9 @@
                     "uniqueItems": true
                 },
                 "quantity": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "number",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1378,15 +1373,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "number",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "unit": {
                     "type": "object",
@@ -1493,15 +1493,9 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1509,15 +1503,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1542,15 +1542,9 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1558,15 +1552,21 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "legalName": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1644,14 +1644,9 @@
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "number",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1659,15 +1654,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "number",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "currency": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1687,14 +1687,9 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "durationInDays": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "integer",
-                                    "null"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1702,15 +1697,20 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 }
             }
         },
@@ -1718,13 +1718,9 @@
             "type": "object",
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
-                            "value": {
-                                "type": [
-                                    "string"
-                                ]
-                            },
                             "releaseDate": {
                                 "format": "date-time",
                                 "type": "string"
@@ -1732,19 +1728,31 @@
                             "releaseID": {
                                 "type": "string"
                             },
+                            "value": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "relationship": {
+                    "type": "array",
                     "items": {
                         "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
                             "value": {
                                 "items": {
                                     "type": "string"
@@ -1756,22 +1764,14 @@
                                 "codelist": "relatedProcess.csv",
                                 "opencodelist": true
                             },
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
                             "releaseTag": {
+                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                },
-                                "type": "array"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1784,568 +1784,6 @@
                 },
                 "uri": {
                     "$ref": "#/definitions/StringNullUriVersioned"
-                }
-            }
-        },
-        "IdentifierUnversioned": {
-            "type": "object",
-            "properties": {
-                "scheme": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "codelist": "organizationIdentifierRegistrationAgency_iati.csv",
-                    "openCodelist": true
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
-                },
-                "legalName": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "uri": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "uri"
-                }
-            },
-            "patternProperties": {
-                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "ClassificationUnversioned": {
-            "type": "object",
-            "properties": {
-                "scheme": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "codelist": "itemClassificationScheme.csv",
-                    "openCodelist": true
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
-                },
-                "description": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "uri": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "uri"
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "AddressUnversioned": {
-            "type": "object",
-            "properties": {
-                "streetAddress": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "locality": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "region": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "postalCode": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "countryName": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "patternProperties": {
-                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "ContactPointUnversioned": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "email": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "telephone": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "faxNumber": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "url": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "uri"
-                }
-            },
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "OrganizationUnversioned": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "id": {
-                    "type": [
-                        "string"
-                    ]
-                },
-                "identifier": {
-                    "$ref": "#/definitions/IdentifierUnversioned"
-                },
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/IdentifierUnversioned"
-                    },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
-                },
-                "address": {
-                    "$ref": "#/definitions/AddressUnversioned"
-                },
-                "contactPoint": {
-                    "$ref": "#/definitions/ContactPointUnversioned"
-                },
-                "roles": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "codelist": "partyRole.csv",
-                    "openCodelist": true
-                },
-                "details": {
-                    "type": [
-                        "object",
-                        "null"
-                    ]
-                }
-            },
-            "patternProperties": {
-                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "OrganizationReferenceUnversioned": {
-            "properties": {
-                "name": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "minLength": 1
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
-                },
-                "identifier": {
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and detailed legal identifier information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
-                    },
-                    "$ref": "#/definitions/IdentifierUnversioned"
-                },
-                "address": {
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and address information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
-                    },
-                    "$ref": "#/definitions/AddressUnversioned"
-                },
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
-                    },
-                    "items": {
-                        "$ref": "#/definitions/IdentifierUnversioned"
-                    },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
-                },
-                "contactPoint": {
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and contact point information for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
-                    },
-                    "$ref": "#/definitions/ContactPointUnversioned"
-                }
-            },
-            "required": [
-                "id",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ItemUnversioned": {
-            "type": "object",
-            "required": [
-                "id"
-            ],
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
-                },
-                "description": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "classification": {
-                    "$ref": "#/definitions/ClassificationUnversioned"
-                },
-                "additionalClassifications": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ClassificationUnversioned"
-                    },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
-                },
-                "quantity": {
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "unit": {
-                    "type": "object",
-                    "properties": {
-                        "scheme": {
-                            "title": "Scheme",
-                            "description": "The list from which units of measure identifiers are taken. This should be an entry from the options available in the [unitClassificationScheme](http://standard.open-contracting.org/1.1-dev/en/schema/codelists/#unit-classification-scheme) codelist. Use of the scheme 'UNCEFACT' for the UN/CEFACT Recommendation 20 list of 'Codes for Units of Measure Used in International Trade' is recommended, although other options are available.",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "codelist": "unitClassificationScheme.csv",
-                            "openCodelist": true
-                        },
-                        "id": {
-                            "title": "ID",
-                            "description": "The identifier from the codelist referenced in the scheme property. Check the codelist for details of how to find and use identifiers from the scheme in use.",
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        },
-                        "name": {
-                            "title": "Name",
-                            "description": "Name of the unit.",
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        },
-                        "value": {
-                            "title": "Value",
-                            "description": "The monetary value of a single unit.",
-                            "$ref": "#/definitions/ValueUnversioned"
-                        },
-                        "uri": {
-                            "title": "URI",
-                            "description": "If the scheme used provide a machine-readable URI for this unit of measure, this can be given.",
-                            "format": "uri",
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    },
-                    "patternProperties": {
-                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "patternProperties": {
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "PeriodUnversioned": {
-            "type": "object",
-            "properties": {
-                "startDate": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "date-time"
-                },
-                "endDate": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "date-time"
-                },
-                "maxExtentDate": {
-                    "format": "date-time",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "durationInDays": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "AmendmentUnversioned": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "date-time"
-                },
-                "rationale": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "id": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "description": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "amendsReleaseID": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "releaseID": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "changes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "property": {
-                                "title": "Property",
-                                "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. (Deprecated in 1.1)",
-                                "type": "string"
-                            },
-                            "former_value": {
-                                "title": "Former Value",
-                                "description": "The previous value of the changed property, in whatever type the property is. (Deprecated in 1.1)",
-                                "type": [
-                                    "string",
-                                    "number",
-                                    "integer",
-                                    "array",
-                                    "object",
-                                    "null"
-                                ]
-                            }
-                        }
-                    },
-                    "deprecated": {
-                        "description": "A free-text or semi-structured string describing the changes made in each amendment can be provided in the amendment.description field. To provide structured information on the fields that have changed, publishers should provide releases indicating the state of the contracting process before and after the amendment.  ",
-                        "deprecatedVersion": "1.1"
-                    }
-                }
-            },
-            "patternProperties": {
-                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "BudgetUnversioned": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
-                },
-                "description": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "amount": {
-                    "$ref": "#/definitions/ValueUnversioned"
-                },
-                "project": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "projectID": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
-                },
-                "uri": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "uri"
-                },
-                "source": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "The budget data source field was intended to link to machine-readable data about the budget for a contracting process, but has been widely mis-used to provide free-text descriptions of budget providers. As a result, it has been removed from version 1.1. budget/uri can be used to provide a link to machine-readable budget information, and budget/description can be used to provide human-readable information on the budget source."
-                    },
-                    "format": "uri"
-                }
-            },
-            "patternProperties": {
-                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
                 }
             }
         },
@@ -2376,23 +1814,6 @@
             },
             "patternProperties": {
                 "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
-        "ValueUnversioned": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "currency": {
                     "type": [
                         "string",
                         "null"
@@ -2632,54 +2053,6 @@
                 }
             }
         },
-        "RelatedProcessUnversioned": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": [
-                        "string"
-                    ]
-                },
-                "relationship": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ],
-                    "codelist": "relatedProcess.csv",
-                    "opencodelist": true
-                },
-                "title": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "scheme": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "codelist": "relatedProcessScheme.csv",
-                    "openCodelist": true
-                },
-                "identifier": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "uri": {
-                    "format": "uri",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            }
-        },
         "AwardUnversioned": {
             "type": "object",
             "required": [
@@ -2781,6 +2154,153 @@
                         "string",
                         "null"
                     ]
+                }
+            }
+        },
+        "ContractUnversioned": {
+            "type": "object",
+            "required": [
+                "id",
+                "awardID"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "awardID": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "status": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "pending",
+                        "active",
+                        "cancelled",
+                        "terminated",
+                        null
+                    ],
+                    "codelist": "contractStatus.csv",
+                    "openCodelist": false
+                },
+                "period": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "value": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/ItemUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "dateSigned": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "implementation": {
+                    "$ref": "#/definitions/ImplementationUnversioned"
+                },
+                "relatedProcesses": {
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/RelatedProcessUnversioned"
+                    },
+                    "type": "array"
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    }
+                },
+                "amendments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AmendmentUnversioned"
+                    }
+                },
+                "amendment": {
+                    "$ref": "#/definitions/AmendmentUnversioned",
+                    "deprecated": {
+                        "description": "The single amendment object has been deprecated in favour of including amendments in an ammendments (plural) array.",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ImplementationUnversioned": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TransactionUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
                 }
             }
         },
@@ -2978,29 +2498,75 @@
                 }
             }
         },
-        "ImplementationUnversioned": {
+        "BudgetUnversioned": {
             "type": "object",
             "properties": {
-                "transactions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/TransactionUnversioned"
-                    },
-                    "uniqueItems": true
+                "id": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
                 },
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/MilestoneUnversioned"
-                    },
-                    "uniqueItems": true
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/DocumentUnversioned"
+                "amount": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "project": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "projectID": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "source": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "The budget data source field was intended to link to machine-readable data about the budget for a contracting process, but has been widely mis-used to provide free-text descriptions of budget providers. As a result, it has been removed from version 1.1. budget/uri can be used to provide a link to machine-readable budget information, and budget/description can be used to provide human-readable information on the budget source."
                     },
-                    "uniqueItems": true
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             }
         },
@@ -3070,11 +2636,121 @@
                 }
             }
         },
-        "ContractUnversioned": {
-            "type": "object",
+        "OrganizationReferenceUnversioned": {
+            "properties": {
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "minLength": 1
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "identifier": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and detailed legal identifier information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/IdentifierUnversioned"
+                },
+                "address": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and address information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/AddressUnversioned"
+                },
+                "additionalIdentifiers": {
+                    "type": "array",
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "items": {
+                        "$ref": "#/definitions/IdentifierUnversioned"
+                    },
+                    "uniqueItems": true,
+                    "wholeListMerge": true
+                },
+                "contactPoint": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and contact point information for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/ContactPointUnversioned"
+                }
+            },
             "required": [
                 "id",
-                "awardID"
+                "name"
+            ],
+            "type": "object"
+        },
+        "OrganizationUnversioned": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "id": {
+                    "type": [
+                        "string"
+                    ]
+                },
+                "identifier": {
+                    "$ref": "#/definitions/IdentifierUnversioned"
+                },
+                "additionalIdentifiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IdentifierUnversioned"
+                    },
+                    "uniqueItems": true,
+                    "wholeListMerge": true
+                },
+                "address": {
+                    "$ref": "#/definitions/AddressUnversioned"
+                },
+                "contactPoint": {
+                    "$ref": "#/definitions/ContactPointUnversioned"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "codelist": "partyRole.csv",
+                    "openCodelist": true
+                },
+                "details": {
+                    "type": [
+                        "object",
+                        "null"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ItemUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
             ],
             "properties": {
                 "id": {
@@ -3084,14 +2760,109 @@
                     ],
                     "minLength": 1
                 },
-                "awardID": {
+                "description": {
                     "type": [
                         "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                        "null"
+                    ]
                 },
-                "title": {
+                "classification": {
+                    "$ref": "#/definitions/ClassificationUnversioned"
+                },
+                "additionalClassifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClassificationUnversioned"
+                    },
+                    "uniqueItems": true,
+                    "wholeListMerge": true
+                },
+                "quantity": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "unit": {
+                    "type": "object",
+                    "properties": {
+                        "scheme": {
+                            "title": "Scheme",
+                            "description": "The list from which units of measure identifiers are taken. This should be an entry from the options available in the [unitClassificationScheme](http://standard.open-contracting.org/1.1-dev/en/schema/codelists/#unit-classification-scheme) codelist. Use of the scheme 'UNCEFACT' for the UN/CEFACT Recommendation 20 list of 'Codes for Units of Measure Used in International Trade' is recommended, although other options are available.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "codelist": "unitClassificationScheme.csv",
+                            "openCodelist": true
+                        },
+                        "id": {
+                            "title": "ID",
+                            "description": "The identifier from the codelist referenced in the scheme property. Check the codelist for details of how to find and use identifiers from the scheme in use.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "name": {
+                            "title": "Name",
+                            "description": "Name of the unit.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "value": {
+                            "title": "Value",
+                            "description": "The monetary value of a single unit.",
+                            "$ref": "#/definitions/ValueUnversioned"
+                        },
+                        "uri": {
+                            "title": "URI",
+                            "description": "If the scheme used provide a machine-readable URI for this unit of measure, this can be given.",
+                            "format": "uri",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "AmendmentUnversioned": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "rationale": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "id": {
                     "type": [
                         "string",
                         "null"
@@ -3103,86 +2874,90 @@
                         "null"
                     ]
                 },
-                "status": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "enum": [
-                        "pending",
-                        "active",
-                        "cancelled",
-                        "terminated",
-                        null
-                    ],
-                    "codelist": "contractStatus.csv",
-                    "openCodelist": false
-                },
-                "period": {
-                    "$ref": "#/definitions/PeriodUnversioned"
-                },
-                "value": {
-                    "$ref": "#/definitions/ValueUnversioned"
-                },
-                "items": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "$ref": "#/definitions/ItemUnversioned"
-                    },
-                    "uniqueItems": true
-                },
-                "dateSigned": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "format": "date-time"
-                },
-                "documents": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/DocumentUnversioned"
-                    },
-                    "uniqueItems": true
-                },
-                "implementation": {
-                    "$ref": "#/definitions/ImplementationUnversioned"
-                },
-                "relatedProcesses": {
-                    "uniqueItems": true,
-                    "items": {
-                        "$ref": "#/definitions/RelatedProcessUnversioned"
-                    },
-                    "type": "array"
-                },
-                "milestones": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/MilestoneUnversioned"
-                    }
-                },
-                "amendments": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/AmendmentUnversioned"
-                    }
-                },
-                "amendment": {
-                    "$ref": "#/definitions/AmendmentUnversioned",
-                    "deprecated": {
-                        "description": "The single amendment object has been deprecated in favour of including amendments in an ammendments (plural) array.",
-                        "deprecatedVersion": "1.1"
-                    }
-                }
-            },
-            "patternProperties": {
-                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                "amendsReleaseID": {
                     "type": [
                         "string",
                         "null"
                     ]
                 },
+                "releaseID": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "property": {
+                                "title": "Property",
+                                "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. (Deprecated in 1.1)",
+                                "type": "string"
+                            },
+                            "former_value": {
+                                "title": "Former Value",
+                                "description": "The previous value of the changed property, in whatever type the property is. (Deprecated in 1.1)",
+                                "type": [
+                                    "string",
+                                    "number",
+                                    "integer",
+                                    "array",
+                                    "object",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "deprecated": {
+                        "description": "A free-text or semi-structured string describing the changes made in each amendment can be provided in the amendment.description field. To provide structured information on the fields that have changed, publishers should provide releases indicating the state of the contracting process before and after the amendment.  ",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ClassificationUnversioned": {
+            "type": "object",
+            "properties": {
+                "scheme": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "itemClassificationScheme.csv",
+                    "openCodelist": true
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
                 "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
                     "type": [
                         "string",
@@ -3191,43 +2966,235 @@
                 }
             }
         },
-        "StringNullDateTimeVersioned": {
-            "items": {
-                "properties": {
-                    "value": {
-                        "format": "date-time",
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "releaseDate": {
-                        "format": "date-time",
-                        "type": "string"
-                    },
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "releaseTag": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    }
+        "IdentifierUnversioned": {
+            "type": "object",
+            "properties": {
+                "scheme": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "organizationIdentifierRegistrationAgency_iati.csv",
+                    "openCodelist": true
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
+                },
+                "legalName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
                 }
             },
-            "type": "array"
+            "patternProperties": {
+                "^(legalName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "AddressUnversioned": {
+            "type": "object",
+            "properties": {
+                "streetAddress": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "locality": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "region": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "postalCode": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "countryName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^(countryName_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ContactPointUnversioned": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "email": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "telephone": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "faxNumber": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "url": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ValueUnversioned": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "currency": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "PeriodUnversioned": {
+            "type": "object",
+            "properties": {
+                "startDate": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "endDate": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "maxExtentDate": {
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "durationInDays": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "RelatedProcessUnversioned": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": [
+                        "string"
+                    ]
+                },
+                "relationship": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "codelist": "relatedProcess.csv",
+                    "opencodelist": true
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "scheme": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "relatedProcessScheme.csv",
+                    "openCodelist": true
+                },
+                "identifier": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "format": "uri",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
         },
         "StringNullUriVersioned": {
+            "type": "array",
             "items": {
                 "properties": {
-                    "value": {
-                        "format": "uri",
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
                     "releaseDate": {
                         "format": "date-time",
                         "type": "string"
@@ -3235,25 +3202,53 @@
                     "releaseID": {
                         "type": "string"
                     },
+                    "value": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri"
+                    },
                     "releaseTag": {
+                        "type": "array",
                         "items": {
                             "type": "string"
-                        },
-                        "type": "array"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
+        },
+        "StringNullDateTimeVersioned": {
+            "type": "array",
+            "items": {
+                "properties": {
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "releaseTag": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         },
         "StringNullVersioned": {
+            "type": "array",
             "items": {
                 "properties": {
-                    "value": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
                     "releaseDate": {
                         "format": "date-time",
                         "type": "string"
@@ -3261,15 +3256,20 @@
                     "releaseID": {
                         "type": "string"
                     },
+                    "value": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
                     "releaseTag": {
+                        "type": "array",
                         "items": {
                             "type": "string"
-                        },
-                        "type": "array"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
         }
     }
 }

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -5,22 +5,8 @@
     "type": "object",
     "properties": {
         "initiationType": {
-            "type": "array",
             "items": {
                 "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
                     "value": {
                         "type": "string",
                         "enum": [
@@ -28,9 +14,23 @@
                         ],
                         "codelist": "initiationType.csv",
                         "openCodelist": false
+                    },
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 }
-            }
+            },
+            "type": "array"
         },
         "parties": {
             "type": "array",
@@ -122,31 +122,31 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer"
                                 ],
                                 "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -155,22 +155,8 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -186,9 +172,23 @@
                                 ],
                                 "codelist": "tenderStatus.csv",
                                 "openCodelist": false
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "procuringEntity": {
                     "$ref": "#/definitions/OrganizationReference"
@@ -219,22 +219,8 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "additionalProcurementCategories": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "array",
@@ -248,9 +234,23 @@
                                 },
                                 "codelist": "extendedProcurementCategory.csv",
                                 "openCodelist": true
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "awardCriteria": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -259,22 +259,8 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "submissionMethod": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "array",
@@ -285,9 +271,23 @@
                                 },
                                 "codelist": "submissionMethod.csv",
                                 "openCodelist": true
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "submissionMethodDetails": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -299,30 +299,30 @@
                     "$ref": "#/definitions/Period"
                 },
                 "hasEnquiries": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "boolean",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "eligibilityCriteria": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -334,57 +334,37 @@
                     "$ref": "#/definitions/Period"
                 },
                 "numberOfTenderers": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "tenderers": {
                     "type": "array",
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "uniqueItems": true,
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/OrganizationUnversioned"
-                                }
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/OrganizationReference"
+                    },
+                    "uniqueItems": true
                 },
                 "documents": {
                     "type": "array",
@@ -458,11 +438,31 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -471,22 +471,8 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -501,9 +487,23 @@
                                 ],
                                 "codelist": "awardStatus.csv",
                                 "openCodelist": false
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "date": {
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
@@ -514,29 +514,9 @@
                 "suppliers": {
                     "type": "array",
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "uniqueItems": true,
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/OrganizationUnversioned"
-                                }
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/OrganizationReference"
+                    },
+                    "uniqueItems": true
                 },
                 "items": {
                     "type": "array",
@@ -593,38 +573,58 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
-                },
-                "awardID": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer"
                                 ],
                                 "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
+                },
+                "awardID": {
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -633,22 +633,8 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -663,9 +649,23 @@
                                 ],
                                 "codelist": "contractStatus.csv",
                                 "openCodelist": false
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "period": {
                     "$ref": "#/definitions/Period"
@@ -769,32 +769,38 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "type": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -812,9 +818,23 @@
                                 ],
                                 "codelist": "milestoneType.csv",
                                 "opencodelist": true
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -832,22 +852,8 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "status": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
@@ -862,9 +868,23 @@
                                 ],
                                 "codelist": "milestoneStatus.csv",
                                 "openCodelist": false
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "documents": {
                     "type": "array",
@@ -900,11 +920,31 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "documentType": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -950,31 +990,31 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -986,31 +1026,31 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "projectID": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "uri": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -1047,11 +1087,31 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "source": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -1100,11 +1160,31 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "identifier": {
                     "deprecated": {
@@ -1122,30 +1202,14 @@
                 },
                 "additionalIdentifiers": {
                     "type": "array",
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "uniqueItems": true,
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/IdentifierUnversioned"
-                                }
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/Identifier"
+                    },
+                    "uniqueItems": true
                 },
                 "contactPoint": {
                     "deprecated": {
@@ -1168,9 +1232,29 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": [
-                        "string"
-                    ]
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "identifier": {
                     "$ref": "#/definitions/Identifier"
@@ -1178,29 +1262,9 @@
                 "additionalIdentifiers": {
                     "type": "array",
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "uniqueItems": true,
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/IdentifierUnversioned"
-                                }
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/Identifier"
+                    },
+                    "uniqueItems": true
                 },
                 "address": {
                     "$ref": "#/definitions/Address"
@@ -1217,30 +1281,30 @@
                     "openCodelist": true
                 },
                 "details": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "object",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 }
             },
             "patternProperties": {
@@ -1259,11 +1323,31 @@
             ],
             "properties": {
                 "id": {
-                    "type": [
-                        "string",
-                        "integer"
-                    ],
-                    "minLength": 1
+                    "items": {
+                        "properties": {
+                            "value": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1274,55 +1358,35 @@
                 "additionalClassifications": {
                     "type": "array",
                     "items": {
-                        "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "uniqueItems": true,
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/ClassificationUnversioned"
-                                }
-                            }
-                        }
-                    }
+                        "$ref": "#/definitions/Classification"
+                    },
+                    "uniqueItems": true
                 },
                 "quantity": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "number",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "unit": {
                     "type": "object",
@@ -1331,10 +1395,7 @@
                             "$ref": "#/definitions/StringNullVersioned"
                         },
                         "id": {
-                            "type": [
-                                "string",
-                                "null"
-                            ]
+                            "$ref": "#/definitions/StringNullVersioned"
                         },
                         "name": {
                             "$ref": "#/definitions/StringNullVersioned"
@@ -1375,10 +1436,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": [
-                        "string",
-                        "null"
-                    ]
+                    "$ref": "#/definitions/StringNullVersioned"
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1392,46 +1450,30 @@
                 "changes": {
                     "type": "array",
                     "items": {
+                        "type": "object",
                         "properties": {
-                            "releaseID": {
+                            "property": {
+                                "title": "Property",
+                                "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. (Deprecated in 1.1)",
                                 "type": "string"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "value": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "property": {
-                                            "title": "Property",
-                                            "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. (Deprecated in 1.1)",
-                                            "type": "string"
-                                        },
-                                        "former_value": {
-                                            "title": "Former Value",
-                                            "description": "The previous value of the changed property, in whatever type the property is. (Deprecated in 1.1)",
-                                            "type": [
-                                                "string",
-                                                "number",
-                                                "integer",
-                                                "array",
-                                                "object",
-                                                "null"
-                                            ]
-                                        }
-                                    }
-                                }
+                            "former_value": {
+                                "title": "Former Value",
+                                "description": "The previous value of the changed property, in whatever type the property is. (Deprecated in 1.1)",
+                                "type": [
+                                    "string",
+                                    "number",
+                                    "integer",
+                                    "array",
+                                    "object",
+                                    "null"
+                                ]
                             }
                         }
+                    },
+                    "deprecated": {
+                        "description": "A free-text or semi-structured string describing the changes made in each amendment can be provided in the amendment.description field. To provide structured information on the fields that have changed, publishers should provide releases indicating the state of the contracting process before and after the amendment.  ",
+                        "deprecatedVersion": "1.1"
                     }
                 }
             },
@@ -1451,31 +1493,31 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1500,31 +1542,31 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "string",
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "legalName": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1602,30 +1644,30 @@
             "type": "object",
             "properties": {
                 "amount": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "number",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "currency": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1645,30 +1687,30 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "durationInDays": {
-                    "type": "array",
                     "items": {
                         "properties": {
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
                             "value": {
                                 "type": [
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 }
             }
         },
@@ -1676,27 +1718,33 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "type": [
-                        "string"
-                    ]
-                },
-                "relationship": {
-                    "type": "array",
                     "items": {
                         "properties": {
+                            "value": {
+                                "type": [
+                                    "string"
+                                ]
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
                             "releaseID": {
                                 "type": "string"
                             },
-                            "releaseDate": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
                             "releaseTag": {
-                                "type": "array",
                                 "items": {
                                     "type": "string"
-                                }
-                            },
+                                },
+                                "type": "array"
+                            }
+                        }
+                    },
+                    "type": "array"
+                },
+                "relationship": {
+                    "items": {
+                        "properties": {
                             "value": {
                                 "items": {
                                     "type": "string"
@@ -1707,9 +1755,23 @@
                                 ],
                                 "codelist": "relatedProcess.csv",
                                 "opencodelist": true
+                            },
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "releaseTag": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
                             }
                         }
-                    }
+                    },
+                    "type": "array"
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1916,7 +1978,8 @@
                     "items": {
                         "$ref": "#/definitions/IdentifierUnversioned"
                     },
-                    "uniqueItems": true
+                    "uniqueItems": true,
+                    "wholeListMerge": true
                 },
                 "address": {
                     "$ref": "#/definitions/AddressUnversioned"
@@ -1948,85 +2011,1265 @@
                 }
             }
         },
-        "StringNullVersioned": {
-            "type": "array",
+        "OrganizationReferenceUnversioned": {
+            "properties": {
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "minLength": 1
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "identifier": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and detailed legal identifier information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/IdentifierUnversioned"
+                },
+                "address": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and address information should only be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/AddressUnversioned"
+                },
+                "additionalIdentifiers": {
+                    "type": "array",
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "items": {
+                        "$ref": "#/definitions/IdentifierUnversioned"
+                    },
+                    "uniqueItems": true,
+                    "wholeListMerge": true
+                },
+                "contactPoint": {
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and contact point information for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                    },
+                    "$ref": "#/definitions/ContactPointUnversioned"
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ],
+            "type": "object"
+        },
+        "ItemUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "classification": {
+                    "$ref": "#/definitions/ClassificationUnversioned"
+                },
+                "additionalClassifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ClassificationUnversioned"
+                    },
+                    "uniqueItems": true,
+                    "wholeListMerge": true
+                },
+                "quantity": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "unit": {
+                    "type": "object",
+                    "properties": {
+                        "scheme": {
+                            "title": "Scheme",
+                            "description": "The list from which units of measure identifiers are taken. This should be an entry from the options available in the [unitClassificationScheme](http://standard.open-contracting.org/1.1-dev/en/schema/codelists/#unit-classification-scheme) codelist. Use of the scheme 'UNCEFACT' for the UN/CEFACT Recommendation 20 list of 'Codes for Units of Measure Used in International Trade' is recommended, although other options are available.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "codelist": "unitClassificationScheme.csv",
+                            "openCodelist": true
+                        },
+                        "id": {
+                            "title": "ID",
+                            "description": "The identifier from the codelist referenced in the scheme property. Check the codelist for details of how to find and use identifiers from the scheme in use.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "name": {
+                            "title": "Name",
+                            "description": "Name of the unit.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "value": {
+                            "title": "Value",
+                            "description": "The monetary value of a single unit.",
+                            "$ref": "#/definitions/ValueUnversioned"
+                        },
+                        "uri": {
+                            "title": "URI",
+                            "description": "If the scheme used provide a machine-readable URI for this unit of measure, this can be given.",
+                            "format": "uri",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "patternProperties": {
+                        "^(name_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "PeriodUnversioned": {
+            "type": "object",
+            "properties": {
+                "startDate": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "endDate": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "maxExtentDate": {
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "durationInDays": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "AmendmentUnversioned": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "rationale": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "amendsReleaseID": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "releaseID": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "property": {
+                                "title": "Property",
+                                "description": "The property name that has been changed relative to the place the amendment is. For example if the contract value has changed, then the property under changes within the contract.amendment would be value.amount. (Deprecated in 1.1)",
+                                "type": "string"
+                            },
+                            "former_value": {
+                                "title": "Former Value",
+                                "description": "The previous value of the changed property, in whatever type the property is. (Deprecated in 1.1)",
+                                "type": [
+                                    "string",
+                                    "number",
+                                    "integer",
+                                    "array",
+                                    "object",
+                                    "null"
+                                ]
+                            }
+                        }
+                    },
+                    "deprecated": {
+                        "description": "A free-text or semi-structured string describing the changes made in each amendment can be provided in the amendment.description field. To provide structured information on the fields that have changed, publishers should provide releases indicating the state of the contracting process before and after the amendment.  ",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "BudgetUnversioned": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "amount": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "project": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "projectID": {
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "source": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "The budget data source field was intended to link to machine-readable data about the budget for a contracting process, but has been widely mis-used to provide free-text descriptions of budget providers. As a result, it has been removed from version 1.1. budget/uri can be used to provide a link to machine-readable budget information, and budget/description can be used to provide human-readable information on the budget source."
+                    },
+                    "format": "uri"
+                }
+            },
+            "patternProperties": {
+                "^(source_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(project_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "PlanningUnversioned": {
+            "type": "object",
+            "properties": {
+                "rationale": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "budget": {
+                    "$ref": "#/definitions/BudgetUnversioned"
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    }
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(rationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ValueUnversioned": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": [
+                        "number",
+                        "null"
+                    ]
+                },
+                "currency": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "TenderUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "status": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "planned",
+                        "active",
+                        "cancelled",
+                        "unsuccessful",
+                        "complete",
+                        null
+                    ],
+                    "codelist": "tenderStatus.csv",
+                    "openCodelist": false
+                },
+                "procuringEntity": {
+                    "$ref": "#/definitions/OrganizationReferenceUnversioned"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ItemUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "value": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "minValue": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "procurementMethod": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "method.csv",
+                    "openCodelist": false
+                },
+                "procurementMethodDetails": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "procurementMethodRationale": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "mainProcurementCategory": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "procurementCategory.csv",
+                    "openCodelist": false
+                },
+                "additionalProcurementCategories": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "codelist": "extendedProcurementCategory.csv",
+                    "openCodelist": true
+                },
+                "awardCriteria": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "awardCriteria.csv",
+                    "openCodelist": true
+                },
+                "awardCriteriaDetails": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "submissionMethod": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "codelist": "submissionMethod.csv",
+                    "openCodelist": true
+                },
+                "submissionMethodDetails": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "tenderPeriod": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "enquiryPeriod": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "hasEnquiries": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
+                "eligibilityCriteria": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "awardPeriod": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "contractPeriod": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "numberOfTenderers": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "tenderers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OrganizationReferenceUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    }
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    }
+                },
+                "amendments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AmendmentUnversioned"
+                    }
+                },
+                "amendment": {
+                    "$ref": "#/definitions/AmendmentUnversioned",
+                    "deprecated": {
+                        "description": "The single amendment object has been deprecated in favour of including amendments in an ammendments (plural) array.",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(procurementMethodRationale_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(awardCriteriaDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(submissionMethodDetails_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "RelatedProcessUnversioned": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": [
+                        "string"
+                    ]
+                },
+                "relationship": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "codelist": "relatedProcess.csv",
+                    "opencodelist": true
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "scheme": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "relatedProcessScheme.csv",
+                    "openCodelist": true
+                },
+                "identifier": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "uri": {
+                    "format": "uri",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "AwardUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "status": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "pending",
+                        "active",
+                        "cancelled",
+                        "unsuccessful",
+                        null
+                    ],
+                    "codelist": "awardStatus.csv",
+                    "openCodelist": false
+                },
+                "date": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "value": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "suppliers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OrganizationReferenceUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/ItemUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "contractPeriod": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "amendments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AmendmentUnversioned"
+                    }
+                },
+                "amendment": {
+                    "$ref": "#/definitions/AmendmentUnversioned",
+                    "deprecated": {
+                        "description": "The single amendment object has been deprecated in favour of including amendments in an ammendments (plural) array.",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "MilestoneUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "type": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "preProcurement",
+                        "engagement",
+                        "approval",
+                        "assessment",
+                        "delivery",
+                        "reporting",
+                        "financing",
+                        null
+                    ],
+                    "codelist": "milestoneType.csv",
+                    "opencodelist": true
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "code": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dueDate": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "dateMet": {
+                    "format": "date-time",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "dateModified": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "scheduled",
+                        "met",
+                        "notMet",
+                        "partiallyMet",
+                        null
+                    ],
+                    "codelist": "milestoneStatus.csv",
+                    "openCodelist": false
+                },
+                "documents": {
+                    "type": "array",
+                    "deprecated": {
+                        "deprecatedVersion": "1.1",
+                        "description": "Inclusion of documents at the milestone level is now deprecated. Documentation should be attached in the tender, award, contract or implementation sections, and titles and descriptions used to highlight the related milestone. Publishers who wish to continue to provide documents at the milestone level should explicitly declare this by using the milestone documents extension."
+                    },
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "DocumentUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "documentType": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "codelist": "documentType.csv",
+                    "openCodelist": true
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "url": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "datePublished": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "dateModified": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "format": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "language": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "ImplementationUnversioned": {
+            "type": "object",
+            "properties": {
+                "transactions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TransactionUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
+                }
+            }
+        },
+        "TransactionUnversioned": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "source": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "date": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "value": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "payer": {
+                    "$ref": "#/definitions/OrganizationReferenceUnversioned"
+                },
+                "payee": {
+                    "$ref": "#/definitions/OrganizationReferenceUnversioned"
+                },
+                "uri": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "uri"
+                },
+                "amount": {
+                    "$ref": "#/definitions/ValueUnversioned",
+                    "deprecated": {
+                        "description": "This field has been replaced by the ```transaction.value``` field for consistency with the use of value and amount elsewhere in the standard.",
+                        "deprecatedVersion": "1.1"
+                    }
+                },
+                "providerOrganization": {
+                    "$ref": "#/definitions/IdentifierUnversioned",
+                    "deprecated": {
+                        "description": "This field has been replaced by the ```transaction.payer``` field to resolve ambiguity arising from 'provider' being interpreted as relating to the goods or services procured rather than the flow of funds between the parties.",
+                        "deprecatedVersion": "1.1"
+                    }
+                },
+                "receiverOrganization": {
+                    "$ref": "#/definitions/IdentifierUnversioned",
+                    "deprecated": {
+                        "description": "This field has been replaced by the ```transaction.payee``` field to resolve ambiguity arising from 'receiver' being interpreted as relating to the goods or services procured rather than the flow of funds between the parties.",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            }
+        },
+        "ContractUnversioned": {
+            "type": "object",
+            "required": [
+                "id",
+                "awardID"
+            ],
+            "properties": {
+                "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "awardID": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "title": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "description": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "status": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "pending",
+                        "active",
+                        "cancelled",
+                        "terminated",
+                        null
+                    ],
+                    "codelist": "contractStatus.csv",
+                    "openCodelist": false
+                },
+                "period": {
+                    "$ref": "#/definitions/PeriodUnversioned"
+                },
+                "value": {
+                    "$ref": "#/definitions/ValueUnversioned"
+                },
+                "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/ItemUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "dateSigned": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date-time"
+                },
+                "documents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DocumentUnversioned"
+                    },
+                    "uniqueItems": true
+                },
+                "implementation": {
+                    "$ref": "#/definitions/ImplementationUnversioned"
+                },
+                "relatedProcesses": {
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/RelatedProcessUnversioned"
+                    },
+                    "type": "array"
+                },
+                "milestones": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/MilestoneUnversioned"
+                    }
+                },
+                "amendments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AmendmentUnversioned"
+                    }
+                },
+                "amendment": {
+                    "$ref": "#/definitions/AmendmentUnversioned",
+                    "deprecated": {
+                        "description": "The single amendment object has been deprecated in favour of including amendments in an ammendments (plural) array.",
+                        "deprecatedVersion": "1.1"
+                    }
+                }
+            },
+            "patternProperties": {
+                "^(title_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "^(description_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "StringNullDateTimeVersioned": {
             "items": {
                 "properties": {
+                    "value": {
+                        "format": "date-time",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
                     "releaseID": {
                         "type": "string"
                     },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
                     "releaseTag": {
-                        "type": "array",
                         "items": {
                             "type": "string"
-                        }
+                        },
+                        "type": "array"
+                    }
+                }
+            },
+            "type": "array"
+        },
+        "StringNullUriVersioned": {
+            "items": {
+                "properties": {
+                    "value": {
+                        "format": "uri",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "releaseTag": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                }
+            },
+            "type": "array"
+        },
+        "StringNullVersioned": {
+            "items": {
+                "properties": {
                     "value": {
                         "type": [
                             "string",
                             "null"
                         ]
-                    }
-                }
-            }
-        },
-        "StringNullDateTimeVersioned": {
-            "type": "array",
-            "items": {
-                "properties": {
+                    },
+                    "releaseDate": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
                     "releaseID": {
                         "type": "string"
                     },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
                     "releaseTag": {
-                        "type": "array",
                         "items": {
                             "type": "string"
-                        }
-                    },
-                    "value": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "date-time"
+                        },
+                        "type": "array"
                     }
                 }
-            }
-        },
-        "StringNullUriVersioned": {
-            "type": "array",
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "releaseTag": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "value": {
-                        "type": [
-                            "string",
-                            "null"
-                        ],
-                        "format": "uri"
-                    }
-                }
-            }
+            },
+            "type": "array"
         }
     }
 }

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -438,31 +438,11 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -573,31 +553,11 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "awardID": {
                     "type": "array",
@@ -769,31 +729,11 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -920,31 +860,11 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "documentType": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -990,31 +910,11 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1087,31 +987,11 @@
             ],
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "source": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -1160,31 +1040,11 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
                 },
                 "identifier": {
                     "deprecated": {
@@ -1202,14 +1062,34 @@
                 },
                 "additionalIdentifiers": {
                     "type": "array",
-                    "deprecated": {
-                        "deprecatedVersion": "1.1",
-                        "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
-                    },
                     "items": {
-                        "$ref": "#/definitions/Identifier"
-                    },
-                    "uniqueItems": true
+                        "properties": {
+                            "releaseDate": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "releaseID": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "array",
+                                "deprecated": {
+                                    "deprecatedVersion": "1.1",
+                                    "description": "From version 1.1, organisations should be referenced by their identifier and name in a document, and additional identifiers for an organisation should be provided in the relevant cross-referenced entry in the parties section at the top level of a release."
+                                },
+                                "items": {
+                                    "$ref": "#/definitions/IdentifierUnversioned"
+                                },
+                                "uniqueItems": true
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 },
                 "contactPoint": {
                     "deprecated": {
@@ -1232,6 +1112,14 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": [
+                        "string"
+                    ]
+                },
+                "identifier": {
+                    "$ref": "#/definitions/Identifier"
+                },
+                "additionalIdentifiers": {
                     "type": "array",
                     "items": {
                         "properties": {
@@ -1243,9 +1131,11 @@
                                 "type": "string"
                             },
                             "value": {
-                                "type": [
-                                    "string"
-                                ]
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/IdentifierUnversioned"
+                                },
+                                "uniqueItems": true
                             },
                             "releaseTag": {
                                 "type": "array",
@@ -1255,16 +1145,6 @@
                             }
                         }
                     }
-                },
-                "identifier": {
-                    "$ref": "#/definitions/Identifier"
-                },
-                "additionalIdentifiers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Identifier"
-                    },
-                    "uniqueItems": true
                 },
                 "address": {
                     "$ref": "#/definitions/Address"
@@ -1323,6 +1203,19 @@
             ],
             "properties": {
                 "id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                "description": {
+                    "$ref": "#/definitions/StringNullVersioned"
+                },
+                "classification": {
+                    "$ref": "#/definitions/Classification"
+                },
+                "additionalClassifications": {
                     "type": "array",
                     "items": {
                         "properties": {
@@ -1334,11 +1227,11 @@
                                 "type": "string"
                             },
                             "value": {
-                                "type": [
-                                    "string",
-                                    "integer"
-                                ],
-                                "minLength": 1
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/ClassificationUnversioned"
+                                },
+                                "uniqueItems": true
                             },
                             "releaseTag": {
                                 "type": "array",
@@ -1348,19 +1241,6 @@
                             }
                         }
                     }
-                },
-                "description": {
-                    "$ref": "#/definitions/StringNullVersioned"
-                },
-                "classification": {
-                    "$ref": "#/definitions/Classification"
-                },
-                "additionalClassifications": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Classification"
-                    },
-                    "uniqueItems": true
                 },
                 "quantity": {
                     "type": "array",
@@ -1436,7 +1316,10 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "$ref": "#/definitions/StringNullVersioned"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1493,31 +1376,11 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1542,31 +1405,11 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "null"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string",
+                        "integer",
+                        "null"
+                    ]
                 },
                 "legalName": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1718,29 +1561,9 @@
             "type": "object",
             "properties": {
                 "id": {
-                    "type": "array",
-                    "items": {
-                        "properties": {
-                            "releaseDate": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "releaseID": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": [
-                                    "string"
-                                ]
-                            },
-                            "releaseTag": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": [
+                        "string"
+                    ]
                 },
                 "relationship": {
                     "type": "array",
@@ -2675,8 +2498,7 @@
                     "items": {
                         "$ref": "#/definitions/IdentifierUnversioned"
                     },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
+                    "uniqueItems": true
                 },
                 "contactPoint": {
                     "deprecated": {
@@ -2714,8 +2536,7 @@
                     "items": {
                         "$ref": "#/definitions/IdentifierUnversioned"
                     },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
+                    "uniqueItems": true
                 },
                 "address": {
                     "$ref": "#/definitions/AddressUnversioned"
@@ -2774,8 +2595,7 @@
                     "items": {
                         "$ref": "#/definitions/ClassificationUnversioned"
                     },
-                    "uniqueItems": true,
-                    "wholeListMerge": true
+                    "uniqueItems": true
                 },
                 "quantity": {
                     "type": [
@@ -2802,7 +2622,8 @@
                             "type": [
                                 "string",
                                 "null"
-                            ]
+                            ],
+                            "versionId": true
                         },
                         "name": {
                             "title": "Name",


### PR DESCRIPTION
Make it use the merge stratagies properly so that it does not hard code
the field name.

Make the unversioned definitions generate automatically, so are not
hardcoded either.

Try and maintain order so diff is not so bad, even though there are few
reordings that were too much work to avoid.