### PR TITLE
Update jsonschema-directive to handle $ref and json pointers differently

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ sphinx-intl==0.9.9
 transifex-client==0.11
 json-merge-patch
 -e git+https://github.com/OpenDataServices/flatten-tool.git@400336bfcfa0feeded14ce1e66f7c817ef2a7652#egg=flattentool
--e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@f809d2c08d6948596af4d4138e8138a420ee4a61#egg=sphinxcontrib-jsonschema
+-e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@919b28c15b74707efb408a673cdd1c2e3fffe0d4#egg=sphinxcontrib-jsonschema
 .

--- a/standard/docs/en/schema/reference.md
+++ b/standard/docs/en/schema/reference.md
@@ -74,8 +74,8 @@ The following details can be provided for each party.
 ```eval_rst
 
 .. jsonschema:: ../../../schema/release-schema.json
-    :include: parties
-    :collapse: parties/identifier,parties/additionalIdentifiers,parties/address,parties/contactPoint
+    :pointer: /definitions/Organization
+    :collapse: identifier,additionalIdentifiers,address,contactPoint
 
 ```
 


### PR DESCRIPTION
http://standard.open-contracting.org/1.1-dev-jsonschema-directive/en/schema/reference/#release includes the correct titles and descriptions.
http://standard.open-contracting.org/1.1-dev-jsonschema-directive/en/schema/reference/#parties is just the bits from /definitions/Organization