### PR TITLE
Update to fix typos in spanish documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ tx push -s
 When the translations are filled in transifex you need to run:
 
 ```
-tx pull -a
+tx pull -a -f
 ```
 
 After this the build script will need to be run again.

--- a/standard/docs/locale/es/LC_MESSAGES/codelists.po
+++ b/standard/docs/locale/es/LC_MESSAGES/codelists.po
@@ -4,13 +4,14 @@
 # 
 # Translators:
 # Oscar Montiel <oscar.montiel@okfn.org>, 2016
+# Tim Davies <tim.davies@opendataservices.coop>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: open-contracting-standard-1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2017-02-17 14:56+0000\n"
-"PO-Revision-Date: 2016-11-12 14:53+0000\n"
-"Last-Translator: Oscar Montiel <oscar.montiel@okfn.org>\n"
+"PO-Revision-Date: 2017-06-15 15:21+0000\n"
+"Last-Translator: Tim Davies <tim.davies@opendataservices.coop>\n"
 "Language-Team: Spanish (http://www.transifex.com/OpenDataServices/open-contracting-standard-1-0/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1070,12 +1071,12 @@ msgid ""
 "tender release with the same ocid, but an earlier releaseDate, before a "
 "tenderAmendment is published. The term amendment has legal meaning in many "
 "jurisdictions."
-msgstr "Una enmienda a una enterga de licitación existente. Debe haber por lo menos una entrega de licitación con el mismo ocid, pero una releaseDate previa, antes de publicar un tenderAmendment. El término enmienda tiene significado legal en varias jurisdicciones."
+msgstr "Una enmienda a una entrega de licitación existente. Debe haber por lo menos una entrega de licitación con el mismo ocid, pero una releaseDate previa, antes de publicar un tenderAmendment. El término enmienda tiene significado legal en varias jurisdicciones."
 
 #. Title_en
 #: schema/codelists/releaseTag.csv:3
 msgid "Tender Amendment"
-msgstr "Enmienta a una Licitación"
+msgstr "Enmienda a una Licitación"
 
 #. Description_en
 #: schema/codelists/releaseTag.csv:4
@@ -1086,7 +1087,12 @@ msgid ""
 "corrections to prior published information. It should not be used for formal"
 " legal amendments to a tender, for which the tenderAmendment tag should be "
 "used. "
-msgstr "Una actualización a una enterga de licitación existente. Debe haber por lo menos una entrega de licitación con el mismo ocid, pero una releaseDate previa, antes de publicar un tenderUpdate. No debe de usarse para enmiendas legales formales a una licitación. Para dichos casos se debe usar la etiqueda tenderAmendment."
+msgstr "Una actualización a una entrega de licitación existente. Debe haber por lo menos una entrega de licitación con el mismo ocid, pero una releaseDate previa, antes de publicar un tenderUpdate. No debe de usarse para enmiendas legales formales a una licitación. Para dichos casos se debe usar la etiqueta tenderAmendment."
+
+#. Title_en
+#: schema/codelists/releaseTag.csv:4
+msgid "Tender Update"
+msgstr "Actualización de Licitación"
 
 #. Title_en
 #: schema/codelists/releaseTag.csv:4


### PR DESCRIPTION
Before merge:
- [x] [Push translations to transifex if any text has changed](https://github.com/open-contracting/standard#translations)
- [x] [Pull completed translations from transifex](https://github.com/open-contracting/standard#translations)

After merge:
- [x] Copy the files from dev to live following the instructions at the top of https://github.com/OpenDataServices/opendataservices-deploy/blob/master/salt/ocds-docs-live.sls