### PR TITLE
Allow breaking words for urls in extension json-highlight

### DIFF
--- a/standard/docs/en/_static/extensions.css
+++ b/standard/docs/en/_static/extensions.css
@@ -19,6 +19,10 @@
     content: url('../../assets/checked_checkbox.png');
 }
 
-.extension-selector-table th:last-child, .extension-selector-table td:last-child{
+.extension-selector-table th:last-child, .extension-selector-table td:last-child {
     display:none;
+}
+
+#using-extensions div.highlight-json div.highlight pre {
+    word-break: break-all;
 }


### PR DESCRIPTION
This avoids an odd layout in the json box for `extensions` when adding urls by selecting from the core and community tables.