### PR TITLE
Typos

### DIFF
--- a/standard/schema/codelists/tenderStatus.csv
+++ b/standard/schema/codelists/tenderStatus.csv
@@ -1,8 +1,8 @@
 Code,Title,Description
-planning,planning,"A future contracting process is being considered. Early information about the process may be provided in the tender section. A process with this status may provide information on early engagement or consultation opportunities, during which the details of a subsequent tender can be shaped."
+planning,Planning,"A future contracting process is being considered. Early information about the process may be provided in the tender section. A process with this status may provide information on early engagement or consultation opportunities, during which the details of a subsequent tender can be shaped."
 planned,Planned,"A contracting process is scheduled, but is not yet taking place. Details of the anticipated dates may be provided in the tender block."
 active,Active,A tender process is currently taking place.
 cancelled,Cancelled,The tender process has been cancelled.
-unsuccessful,Unsuccessful,The tender process was unsucessful.
+unsuccessful,Unsuccessful,The tender process was unsuccessful.
 complete,Complete,The tender process is complete. 
 withdrawn,Withdrawn,"No further information on this process is available under this ocid."


### PR DESCRIPTION
Noticed a couple of small typos when playing around with the source and reading about codelists:

planning -> Planning, unsucessful -> unsuccessful

Thought I'd send a PR through with 'em!  (Couldn't stop either emacs or the github web editor adding the newline at the end of the file though...)