### PR TITLE
Fix schema links

### DIFF
--- a/standard/docs/en/schema/record_package.md
+++ b/standard/docs/en/schema/record_package.md
@@ -2,9 +2,9 @@
 
 The record package schema describes the container structure for publishing records. The contents of a record are based on the release schema. The package contains important meta-data.
 
-You can view an interactive version of the record schema below (requires javascript) or [download this version of the schema here](../../../record-package-schema.json).
+You can view an interactive version of the record schema below (requires javascript) or [download this version of the schema here](../../../../record-package-schema.json).
 
-A separate, auto-generated, [versioned release validation schema](../../../versioned-release-validation-schema.json) is provided for validating releases within fully versioned records.
+A separate, auto-generated, [versioned release validation schema](../../../../versioned-release-validation-schema.json) is provided for validating releases within fully versioned records.
 
 Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section.
 

--- a/standard/docs/en/schema/release.md
+++ b/standard/docs/en/schema/release.md
@@ -1,6 +1,6 @@
 # Release Schema
 
-The release schema provides the authoritative definition of fields and their structure. You can view an interactive version of the release schema below (requires javascript) or [download this version of the schema here](../../../release-schema.json).
+The release schema provides the authoritative definition of fields and their structure. You can view an interactive version of the release schema below (requires javascript) or [download this version of the schema here](../../../../release-schema.json).
 
 The release schema is used to validate the contents of the ```releases``` array of [release packages](release_package.md), and the ```compiledReleases``` array of releases in a [record package](record_package.md).
 

--- a/standard/docs/en/schema/release_package.md
+++ b/standard/docs/en/schema/release_package.md
@@ -2,7 +2,7 @@
 
 The release package schema describes the container document for publishing releases. The package contains important meta-data.
 
-You can view an interactive version of the release schema below (requires javascript) or [download this version of the schema here](../../../release-package-schema.json).
+You can view an interactive version of the release schema below (requires javascript) or [download this version of the schema here](../../../../release-package-schema.json).
 
 Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section.
 


### PR DESCRIPTION
The links to the json schemas in the live version of 1.1 are broken - this PR fixes them

@Bjwebb @timgdavies checking that merging this into 1.1-dev is the right way to get it into the 1.1.1 bugfix