### PR TITLE
1.0.3 Release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.2] - 2016-TBC
+## [1.0.3] - 2017-07-31
+
+### Fixed
+
+* [#329](https://github.com/open-contracting/standard/issues/329) - updated ```item.quantity``` to support decimal values (integer -> number)
+* [#253](https://github.com/open-contracting/standard/issues/253) - updated ```value.amount``` to support negative values
+
+## [1.0.2] - 2016
 
 ### Changed
 

--- a/standard/docs/en/schema/changelog.md
+++ b/standard/docs/en/schema/changelog.md
@@ -4,4 +4,45 @@ OCDS is currently in version 1.0.
 
 In February 2016, updated documentation was released. This did not make any semantic changes to the standard. 
 
-<!-- ToDo: Add bug-fix changelog for 1.0 -->
+## [1.0.3] - 2017-07-31
+
+### Fixed
+
+* [#329](https://github.com/open-contracting/standard/issues/329) - updated ```item.quantity``` to support decimal values (integer -> number)
+* [#253](https://github.com/open-contracting/standard/issues/253) - updated ```value.amount``` to support negative values
+
+## [1.0.2] - 2016
+
+### Changed
+
+### Fixed
+
+- Added titles to all fields in the documentation (#362)
+- Missing field ```procurementMethodDetails``` added to schema (#221)
+- Typo fix in releaseTag (#391)
+- Fixing links to Fiscal Data Package (#271)
+- Description for ```numberOfTenderers``` (#314)
+- Fixed definition of ```changes``` (#244)
+- Updated documentation to refer to 'Object' not 'Reference' for fields (#228)
+
+### Tidy up
+
+- Removed the old Spanish documentation translations folders from ```standard/docs/es```
+- Added CSV download links for registered OCIDs, and publication levels
+- Updated publication levels spreadsheet to reflect version 1.0.2
+
+## [1.0] - 2015-07-29
+
+### Changed
+
+- ```contractPeriod``` added to ```award``` to allow the anticipated period of a contract to be recorded, without requiring the creation of a contract block. Discussed in [#199](https://github.com/open-contracting/standard/issues/199)
+
+- Updated codelists
+
+### Fixed
+
+- Minor documentation fixes.
+
+## [1.0.RC] - 2014-11-18
+
+Changes prior to this point are not covered by this changelog. A non-exhaustive overview of changes between the beta release and 1.0.RC can be [found on the project blog](http://standard.open-contracting.org/release-of-data-standard/).

--- a/standard/schema/record-package-schema.json
+++ b/standard/schema/record-package-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://standard.open-contracting.org/schema/1__0__2/record-package-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__3/record-package-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Record package",
     "description": "The record package contains a list of records along with some publishing meta data. The records pull together all the releases under a single Open Contracting ID and compile them into the latest version of the information along with the history of any data changes.",
@@ -123,7 +123,7 @@
                             "description": "A list of releases, with all the data. The releases MUST be sorted into date order in the array, from oldest (at position 0) to newest (last).",
                             "type": "array",
                             "items": {
-                                "$ref": "http://standard.open-contracting.org/schema/1__0__2/release-schema.json"
+                                "$ref": "http://standard.open-contracting.org/schema/1__0__3/release-schema.json"
                             },
                             "minItems": 1
                         }
@@ -132,12 +132,12 @@
                 "compiledRelease": {
                     "title": "Compiled release",
                     "description": "This is the latest version of all the contracting data, it has the same schema as an open contracting release.",
-                    "$ref": "http://standard.open-contracting.org/schema/1__0__2/release-schema.json"
+                    "$ref": "http://standard.open-contracting.org/schema/1__0__3/release-schema.json"
                 },
                 "versionedRelease": {
                     "title": "Versioned release",
                     "description": "This contains the history of the data in the compiledRecord. With all versions of the information and the release they came from.",
-                    "$ref": "http://standard.open-contracting.org/schema/1__0__2/versioned-release-validation-schema.json"
+                    "$ref": "http://standard.open-contracting.org/schema/1__0__3/versioned-release-validation-schema.json"
                 }
             },
             "required": ["ocid", "releases"]

--- a/standard/schema/release-package-schema.json
+++ b/standard/schema/release-package-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://standard.open-contracting.org/schema/1__0__2/release-package-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__3/release-package-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Release Package",
     "description": "Note that all releases within a release package must have a unique releaseID within this release package.",
@@ -20,7 +20,7 @@
         "releases": {
             "type": "array",
             "minItems": 1,
-            "items": { "$ref": "http://standard.open-contracting.org/schema/1__0__2/release-schema.json" },
+            "items": { "$ref": "http://standard.open-contracting.org/schema/1__0__3/release-schema.json" },
             "uniqueItems": true
         },
         "publisher": { 

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -819,7 +819,7 @@
                     "description": "The number of units required",
                     "mergeStrategy": "ocdsVersion",
                     "minimum": 0,
-                    "type": ["integer", "null"]
+                    "type": ["number", "null"]
                 },
                 "unit": {
                     "title":"Unit",
@@ -1062,7 +1062,6 @@
                     "title":"Amount",
                     "description": "Amount as a number.",
                     "type": ["number", "null"],
-                    "minimum": 0,
                     "mergeStrategy": "ocdsVersion"
                 },
                 "currency": {

--- a/standard/schema/release-schema.json
+++ b/standard/schema/release-schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://standard.open-contracting.org/schema/1__0__2/release-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__3/release-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for an Open Contracting Release",
     "type": "object",

--- a/standard/schema/utils/make_validation_schema.py
+++ b/standard/schema/utils/make_validation_schema.py
@@ -95,7 +95,7 @@ def add_string_definitions(schema):
 
 
 def get_versioned_validation_schema(versioned_release):
-    versioned_release["id"] = "http://standard.open-contracting.org/schema/1__0__2/versioned-release-validation-schema.json"  # nopep8
+    versioned_release["id"] = "http://standard.open-contracting.org/schema/1__0__3/versioned-release-validation-schema.json"  # nopep8
     versioned_release["$schema"] = "http://json-schema.org/draft-04/schema#"  # nopep8
     versioned_release["title"] = "Schema for a compiled, versioned Open Contracting Release."  # nopep8
 

--- a/standard/schema/versioned-release-validation-schema.json
+++ b/standard/schema/versioned-release-validation-schema.json
@@ -1,10 +1,11 @@
 {
-    "id": "http://standard.open-contracting.org/schema/1__0__2/versioned-release-validation-schema.json",
+    "id": "http://standard.open-contracting.org/schema/1__0__3/versioned-release-validation-schema.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Schema for a compiled, versioned Open Contracting Release.",
     "type": "object",
     "properties": {
         "initiationType": {
+            "type": "array",
             "items": {
                 "properties": {
                     "releaseID": {
@@ -16,19 +17,18 @@
                             "tender"
                         ]
                     },
-                    "releaseTag": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "releaseDate": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "releaseTag": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
         },
         "planning": {
             "$ref": "#/definitions/Planning"
@@ -100,6 +100,7 @@
             ],
             "properties": {
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -111,19 +112,18 @@
                                     "integer"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -132,6 +132,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -151,19 +152,18 @@
                                     null
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "items": {
                     "type": "array",
@@ -179,6 +179,7 @@
                     "$ref": "#/definitions/Value"
                 },
                 "procurementMethod": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -196,19 +197,18 @@
                                     null
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "procurementMethodDetails": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -223,6 +223,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "submissionMethod": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -237,19 +238,18 @@
                                     "type": "string"
                                 }
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "submissionMethodDetails": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -261,6 +261,7 @@
                     "$ref": "#/definitions/Period"
                 },
                 "hasEnquiries": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -272,19 +273,18 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "eligibilityCriteria": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -293,6 +293,7 @@
                     "$ref": "#/definitions/Period"
                 },
                 "numberOfTenderers": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -304,46 +305,45 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "tenderers": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
-                                "uniqueItems": true,
+                                "type": "array",
                                 "items": {
                                     "$ref": "#/definitions/OrganizationUnversioned"
                                 },
-                                "type": "array"
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                "uniqueItems": true
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "procuringEntity": {
                     "$ref": "#/definitions/Organization"
@@ -422,6 +422,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -440,19 +441,18 @@
                                     null
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "date": {
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
@@ -461,31 +461,31 @@
                     "$ref": "#/definitions/Value"
                 },
                 "suppliers": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
-                                "uniqueItems": true,
+                                "type": "array",
                                 "items": {
                                     "$ref": "#/definitions/OrganizationUnversioned"
                                 },
-                                "type": "array"
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                "uniqueItems": true
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "items": {
                     "type": "array",
@@ -538,6 +538,7 @@
                     ]
                 },
                 "awardID": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -549,19 +550,18 @@
                                     "integer"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "title": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -570,6 +570,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -588,19 +589,18 @@
                                     null
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "period": {
                     "$ref": "#/definitions/Period"
@@ -699,6 +699,7 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "status": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -716,19 +717,18 @@
                                     null
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "documents": {
                     "type": "array",
@@ -812,6 +812,7 @@
                     "$ref": "#/definitions/StringNullUriVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -824,19 +825,18 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -848,6 +848,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "projectID": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -860,19 +861,18 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "uri": {
                     "$ref": "#/definitions/StringNullUriVersioned"
@@ -938,31 +938,31 @@
                     "$ref": "#/definitions/Identifier"
                 },
                 "additionalIdentifiers": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
-                                "uniqueItems": true,
+                                "type": "array",
                                 "items": {
                                     "$ref": "#/definitions/IdentifierUnversioned"
                                 },
-                                "type": "array"
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                "uniqueItems": true
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "name": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1002,33 +1002,34 @@
                     "$ref": "#/definitions/Classification"
                 },
                 "additionalClassifications": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
-                                "uniqueItems": true,
+                                "type": "array",
                                 "items": {
                                     "$ref": "#/definitions/ClassificationUnversioned"
                                 },
-                                "type": "array"
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                "uniqueItems": true
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "quantity": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -1037,23 +1038,22 @@
                             "value": {
                                 "minimum": 0,
                                 "type": [
-                                    "integer",
+                                    "number",
                                     "null"
                                 ]
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "unit": {
                     "type": "object",
@@ -1091,12 +1091,14 @@
                     "$ref": "#/definitions/StringNullDateTimeVersioned"
                 },
                 "changes": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
                                 "type": "string"
                             },
                             "value": {
+                                "type": "array",
                                 "items": {
                                     "type": "object",
                                     "properties": {
@@ -1118,22 +1120,20 @@
                                             ]
                                         }
                                     }
-                                },
-                                "type": "array"
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                }
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "rationale": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1155,6 +1155,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -1167,19 +1168,18 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "description": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1204,6 +1204,7 @@
                     "$ref": "#/definitions/StringNullVersioned"
                 },
                 "id": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -1216,19 +1217,18 @@
                                     "null"
                                 ]
                             },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "legalName": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1306,6 +1306,7 @@
             "type": "object",
             "properties": {
                 "amount": {
+                    "type": "array",
                     "items": {
                         "properties": {
                             "releaseID": {
@@ -1315,22 +1316,20 @@
                                 "type": [
                                     "number",
                                     "null"
-                                ],
-                                "minimum": 0
-                            },
-                            "releaseTag": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                ]
                             },
                             "releaseDate": {
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "releaseTag": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    },
-                    "type": "array"
+                    }
                 },
                 "currency": {
                     "$ref": "#/definitions/StringNullVersioned"
@@ -1549,6 +1548,7 @@
             }
         },
         "StringNullDateTimeVersioned": {
+            "type": "array",
             "items": {
                 "properties": {
                     "releaseID": {
@@ -1561,47 +1561,21 @@
                         ],
                         "format": "date-time"
                     },
-                    "releaseTag": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "releaseDate": {
                         "type": "string",
                         "format": "date-time"
-                    }
-                }
-            },
-            "type": "array"
-        },
-        "StringNullVersioned": {
-            "items": {
-                "properties": {
-                    "releaseID": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": [
-                            "string",
-                            "null"
-                        ]
                     },
                     "releaseTag": {
+                        "type": "array",
                         "items": {
                             "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "releaseDate": {
-                        "type": "string",
-                        "format": "date-time"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
         },
         "StringNullUriVersioned": {
+            "type": "array",
             "items": {
                 "properties": {
                     "releaseID": {
@@ -1614,19 +1588,44 @@
                         ],
                         "format": "uri"
                     },
+                    "releaseDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
                     "releaseTag": {
+                        "type": "array",
                         "items": {
                             "type": "string"
-                        },
-                        "type": "array"
+                        }
+                    }
+                }
+            }
+        },
+        "StringNullVersioned": {
+            "type": "array",
+            "items": {
+                "properties": {
+                    "releaseID": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
                     "releaseDate": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "releaseTag": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
-            },
-            "type": "array"
+            }
         }
     }
 }


### PR DESCRIPTION
OCDS 1.0.3, with minor fixes, is found at http://standard.open-contracting.org/1.0.3-dev/en/ with a [changelog here](http://standard.open-contracting.org/1.0.3-dev/en/schema/changelog/). 

Please use this pull request to raise any questions or concerns about this patch release.

Patch releases are backwards compatible (or correct unintentional errors in earlier schema or documentation releases), and so do not go through the full upgrade process. **This patch releases will become the main versions for 1.0 in 7 days unless substantive objections are raised.**

This should not impact on existing published data (apart from where schema errors have been causing validation problems), although publishers may wish to review the changelog to identify areas where they can improve the alignment of values to updated open codelists.

# Change log

## [1.0.3] - 2017-07-31

### Fixed

* [#329](https://github.com/open-contracting/standard/issues/329) - updated ```item.quantity``` to support decimal values (integer -> number)
* [#253](https://github.com/open-contracting/standard/issues/253) - updated ```value.amount``` to support negative values
