### PR TITLE
Don't open docson (schema viewer) links in iframe

### DIFF
--- a/standard/docs/en/_static/docson/lib/marked.js
+++ b/standard/docs/en/_static/docson/lib/marked.js
@@ -844,7 +844,7 @@
     };
 
     Renderer.prototype.link = function(href, title, text) {
-        var out = '<a href="' + href + '"';
+        var out = '<a target="_top" href="' + href + '"';
         if (title) {
             out += ' title="' + title + '"';
         }


### PR DESCRIPTION
#537 

Link to test this http://standard.open-contracting.org/537-docson-links/en/schema/release/