### PR TITLE
Add note on required fields in schema viewer

### DIFF
--- a/standard/docs/en/schema/release.md
+++ b/standard/docs/en/schema/release.md
@@ -6,6 +6,6 @@ The release schema is used to validate the contents of the ```releases``` array 
 
 ## Release schema
 
-Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section.
+Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section. Required fields are indicated in **bold**.
 
 <script src="../../_static/docson/widget.js" data-schema="../../release-schema.json"></script>

--- a/test_docs.py
+++ b/test_docs.py
@@ -89,6 +89,7 @@ def test_community_extensions(browser, server, lang):
     assert cells[3].text == 'ppp, 1.1'
 
     assert 'ocds_budget_breakdown_extension' not in browser.find_element_by_id('using-extensions').text
+    browser.execute_script("arguments[0].scrollIntoView();", cells[0])
     cells[0].click()
     assert 'ocds_budget_breakdown_extension' in browser.find_element_by_id('using-extensions').text
 


### PR DESCRIPTION
Required fields are shown in bold in the schema viewer but we don't explain that anywhere