### PR TITLE
Typographic updates to contributors agreement (cherry picked onto 1.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You confirm that:
 
 (c) The grant of rights under Section 2 does not violate any grant of rights which You or Your Affiliates have made to third parties.
 
-(d) You have followed the instructions in , if You do not own the Copyright in the entire work of authorship Submitted.
+(d) You have followed the instructions in §1, if You do not own the Copyright in the entire work of authorship Submitted.
 
 ## 4. Disclaimer
 
@@ -85,3 +85,23 @@ TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL YOU OR US BE
 6.4 The failure of either party to require performance by the other party of any provision of this Agreement in one situation shall not affect the right of a party to require such performance at any time in the future. A waiver of performance under a provision in one situation shall not be considered a waiver of the performance of the provision in the future or a waiver of the provision in its entirety.
 
 6.5 If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and which is enforceable. The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+## Signature 
+
+Signature:
+
+Date:
+
+Name:
+
+Title:
+
+Company Name:
+
+Mailing Address:
+
+Telephone:
+
+Email:
+
+Project Name:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ You confirm that:
 
 (c) The grant of rights under Section 2 does not violate any grant of rights which You or Your Affiliates have made to third parties.
 
-(d) You have followed the instructions in §1, if You do not own the Copyright in the entire work of authorship Submitted.
+(d) You have followed the instructions in Section 1, if You do not own the Copyright in the entire work of authorship Submitted.
 
 ## 4. Disclaimer
 


### PR DESCRIPTION
See https://github.com/open-contracting/standard/pull/567 for the original pull request for 1.1