### PR TITLE
Add a privacy notice

### DIFF
--- a/standard/docs/en/_templates/footer.html
+++ b/standard/docs/en/_templates/footer.html
@@ -1,4 +1,5 @@
 {% extends "!footer.html" %}
 {% block extrafooter %}
     {{ super() }}
+    <a href="{{ pathto('privacy-notice') }}">Privacy Notice</a>
 {% endblock %}

--- a/standard/docs/en/privacy-notice.md
+++ b/standard/docs/en/privacy-notice.md
@@ -36,8 +36,6 @@ Personal data we collect:
 
 We do not use this data to personally identify individuals, but it is possible that it could be used to do so, particularly if combined with other datasets.
 
-You can opt out of this processing: If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Matomo will not track your visit.
-
 Data processors: Google Analytics, Open Data Services Co-operative Limited
 
 The data controller (Open Contracting Partnership) is based in the USA.

--- a/standard/docs/en/privacy-notice.md
+++ b/standard/docs/en/privacy-notice.md
@@ -42,7 +42,7 @@ Data processors: Google Analytics, Open Data Services Co-operative Limited
 
 The data controller (Open Contracting Partnership) is based in the USA.
 
-Data is transferred to Google Analytics, we may transfer data to third countries (non-EEA).
+Data is transferred to Google Analytics, who may transfer data to third countries (non-EEA).
 
 The data is kept indefinitely, in pseudonymised form.
 

--- a/standard/docs/en/privacy-notice.md
+++ b/standard/docs/en/privacy-notice.md
@@ -1,0 +1,65 @@
+Privacy Notice
+--------------
+
+Open Contracting Partnership is committed to ensuring that your privacy is protected. This privacy notice sets out how we collect and process any personal data when you use this website.
+
+We may change this notice from time to time by updating this page. This notice is effective from 24th May 2018.
+
+Data controller:  
+Open Contracting Partnership, [data@open-contracting.org](mailto:data@open-contracting.org), who are based in the USA.  
+Contact us if would like a copy of the information held on you or if you believe that any information we are holding on you is incorrect or incomplete.
+
+You have the following rights concerning this data:
+
+*   Right to be informed, which is the purpose of this privacy notice
+*   Right to Access, Rectification, Erasure, and to Restrict Processing. Note that the right to Erasure and Restrict Processing are balanced against our legitimate interests. Where relevant, you need to provide information to re-identify yourself from our pseudonymised data, see [GDPR Article 11](https://gdpr-info.eu/art-11-gdpr/)
+*   Right to object to our processing.
+
+Our supervisory authority is the [ICO in the UK](https://ico.org.uk/). You have the right to lodge a complaint with them.
+
+We process personal data for the following purposes:
+
+*   Understanding website visitor and traffic patterns
+*   Understanding server behaviour
+
+We rely on [legitimate interests](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/legitimate-interests/) ([GDPR Article 6(1)(f)](https://gdpr-info.eu/art-6-gdpr/)) as the lawful basis for this processing. Details about the type of data, the purpose of the processing and legitimate interests, and the storage and retention of the data are set out below.
+
+### Understanding website visitor and traffic patterns
+
+We collect data about your visits to the website, for the purpose of analysing how the website is used, so that we can improve it. We use Google Analytics for this.
+
+Personal data we collect:
+
+*   Your IP address
+*   Referrer (what page you arrived at one of our web pages from)
+*   Information about your device, OS and browser
+
+We do not use this data to personally identify individuals, but it is possible that it could be used to do so, particularly if combined with other datasets.
+
+You can opt out of this processing: If you have set your web browser to "I do not want to be tracked" (DoNotTrack is enabled) then Matomo will not track your visit.
+
+Data processors: Google Analytics, Open Data Services Co-operative Limited
+
+The data controller (Open Contracting Partnership) is based in the USA.
+
+Data is transferred to Google Analytics, we may transfer data to third countries (non-EEA).
+
+The data is kept indefinitely, in pseudonymised form.
+
+### Understanding server behaviour
+
+We collect data about your visits to the website in server logs. This is for the purpose of debugging network issues, monitoring server usage, and identifying malicious usage.
+
+Personal data we collect:
+
+*   Your IP address
+*   User agent (information about the OS and browser that you use)
+*   Referrer (what page you arrived at one of our web pages from)
+
+We do not use this data to personally identify individuals, but it is possible that it could be used to do so, particularly if combined with other datasets.
+
+Data processors: Open Data Services Co-operative Limited, Bytemark.
+
+The data controller (Open Contracting Partnership) is based in the USA.
+
+The data is kept indefinitely.


### PR DESCRIPTION
http://standard.open-contracting.org/privacy-notice/en/privacy-notice/

I think we should put this live in English only, which is the same as the main OC Privacy Policy. Then we can discuss whether it should be translated.