### PR TITLE
Use new registry format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@
 .ve
 venv
 
-/*.egg-info
 /build
+/cache.sqlite
 /chromedriver
 /chromedriver_linux64.zip
 /chromedriver_mac64.zip

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -3,8 +3,8 @@
 
 # The following lines are updated based on the `repos:dependencies` task in standard-maintenance-scripts.
 
--e git+https://github.com/open-contracting/documentation-support.git@15c73ba2b5fd3c7fc6dbf3a81fdba4ea3dfd4aec#egg=ocds_documentation_support
--e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@f193169306956806653dee8fb1b40c720a6f61f1#egg=sphinxcontrib-opencontracting
+-e git+https://github.com/open-contracting/documentation-support.git@27e00d5c129cd3e0f93343dfc75dc0f9c4cb1cca#egg=ocds_documentation_support
+-e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@03732f745245855114202be941f378fd9dfbc9ab#egg=sphinxcontrib-opencontracting
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@e39a92f4238bf022db11e4e88ba92fdaff2b31c9#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
 

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -3,8 +3,8 @@
 
 # The following lines are updated based on the `repos:dependencies` task in standard-maintenance-scripts.
 
--e git+https://github.com/open-contracting/documentation-support.git@27e00d5c129cd3e0f93343dfc75dc0f9c4cb1cca#egg=ocds_documentation_support
--e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@03732f745245855114202be941f378fd9dfbc9ab#egg=sphinxcontrib-opencontracting
+-e git+https://github.com/open-contracting/documentation-support.git@22fc9726fae871e89803a2c85213dbf1c4746654#egg=ocds_documentation_support
+-e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@262373e82d23a3cb928bfb513b0b3e057b3eccad#egg=sphinxcontrib-opencontracting
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@e39a92f4238bf022db11e4e88ba92fdaff2b31c9#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices
 

--- a/standard/docs/en/conf.py
+++ b/standard/docs/en/conf.py
@@ -116,8 +116,16 @@ html_static_path = ['_static']
 
 locale_dirs = ['../locale/', os.path.join(standard_theme.get_html_theme_path(), 'locale')]
 gettext_compact = False
-
-extension_registry_git_ref = 'v{}'.format(release)
+default_extension_version = 'v{}'.format(release)
+extension_versions = {
+    'bids': default_extension_version,
+    'enquiries': default_extension_version,
+    'location': default_extension_version,
+    'lots': default_extension_version,
+    'milestone_documents': default_extension_version,
+    'participation_fee': default_extension_version,
+    'process_title': default_extension_version,
+}
 
 # NOTE: The following two options may no longer be relevant.
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
@@ -127,6 +135,7 @@ html_show_copyright = False
 
 
 def setup(app):
+    app.add_config_value('extension_versions', extension_versions, True)
     app.add_config_value('recommonmark_config', {
         'enable_eval_rst': True
     }, True)

--- a/standard/schema/utils/fetch_core_extensions.py
+++ b/standard/schema/utils/fetch_core_extensions.py
@@ -4,22 +4,21 @@ Add an extra Metadata section to the top of each file.
 Download codelists used by documentation to extension /codelists/
 """
 
+import csv
 import os.path
-import re
 import sys
+from io import StringIO
+from urllib.parse import urlparse
 
 import requests
+from ocdsextensionregistry import ExtensionRegistry
 
 docs_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'docs', 'en')
 sys.path.append(docs_path)
 
-from conf import extension_registry_git_ref  # noqa
+from conf import extension_versions  # noqa
 
-
-url = 'http://standard.open-contracting.org/extension_registry/{}/extensions.json'
-extension_json = requests.get(url.format(extension_registry_git_ref)).json()
-
-metadata = '''
+metadata = """
 
 ## Metadata
 
@@ -32,30 +31,37 @@ To use this extension, include its URL in the `extension` array of your release 
 }}
 ```
 
-This extension is maintained at [{}]({})
+This extension is maintained at <{}>
 
 ## Documentation
-'''
+"""
 
 
-path = os.path.join(docs_path, 'extensions')
-for extension in extension_json['extensions']:
-    if extension['core']:
-        match = re.match('https://raw.githubusercontent.com/open-contracting/([^/]*)/', extension['url'])
-        repo_url = 'https://github.com/open-contracting/{}'.format(match.group(1))
+extensions_path = os.path.join(docs_path, 'extensions')
 
-        response = requests.get(extension['url'].rstrip('/') + '/' + 'README.md')
-        lines = response.text.split('\n')
-        heading = '\n'.join(lines[:1])
-        body = '\n'.join(lines[1:])
-        body = body.replace('\n##', '\n###')
-        text = heading + metadata.format(extension['url'], repo_url, repo_url) + body
+extensions_url = 'https://raw.githubusercontent.com/open-contracting/extension_registry/master/extensions.csv'
+extension_versions_url = 'https://raw.githubusercontent.com/open-contracting/extension_registry/master/extension_versions.csv'  # noqa
 
-        with open(os.path.join(path, extension['slug'] + '.md'), 'w') as f:
-            f.write(text)
+extension_registry = ExtensionRegistry(extension_versions_url, extensions_url)
 
-        extension_json = requests.get(extension['url'].rstrip('/') + '/' + 'extension.json').json()
-        for codelist in extension_json.get('codelists', []):
-            response = requests.get(extension['url'].rstrip('/') + '/codelists/' + codelist)
-            with open(os.path.join(path, 'codelists', codelist), 'w') as f:
-                f.write(response.text)
+# At present, all core extensions are included in the standard's documentation.
+for version in extension_registry.filter(core=True):
+    if version.id not in extension_versions:
+        raise Exception('{} is a core extension but is not included in the standard'.format(version.id))
+
+for identifier, version in extension_versions.items():
+    extension = extension_registry.get(id=identifier, version=version)
+    response = requests.get(extension.base_url + 'README.md')
+    lines = response.text.split('\n')
+    heading = '\n'.join(lines[:1])
+    body = '\n'.join(lines[1:])
+    body = body.replace('\n##', '\n###')
+    text = heading + metadata.format(extension.base_url, extension.repository_html_page) + body
+
+    with open(os.path.join(extensions_path, '{}.md'.format(extension.id)), 'w') as f:
+        f.write(text)
+
+    for codelist in extension.metadata.get('codelists', []):
+        response = requests.get(extension.base_url + 'codelists/' + codelist)
+        with open(os.path.join(extensions_path, 'codelists', codelist), 'w') as f:
+            f.write(response.text)

--- a/standard/schema/utils/fetch_core_extensions.py
+++ b/standard/schema/utils/fetch_core_extensions.py
@@ -4,11 +4,8 @@ Add an extra Metadata section to the top of each file.
 Download codelists used by documentation to extension /codelists/
 """
 
-import csv
 import os.path
 import sys
-from io import StringIO
-from urllib.parse import urlparse
 
 import requests
 from ocdsextensionregistry import ExtensionRegistry

--- a/test_docs.py
+++ b/test_docs.py
@@ -85,7 +85,7 @@ def test_community_extensions(browser, server, lang):
     browser.get('{}{}/extensions'.format(server, lang))
     community_extensions = browser.find_element_by_id('community-extensions').find_element_by_tag_name('table')
     # Currently community extensions aren't translated
-    link = community_extensions.find_element_by_link_text('Budget breakdown')
+    link = community_extensions.find_element_by_link_text('Budget Breakdown')
     assert (link.get_attribute('href') ==
             'https://github.com/open-contracting/ocds_budget_breakdown_extension/blob/master/README.md')
     cells = link.find_elements_by_xpath('../../td')

--- a/test_docs.py
+++ b/test_docs.py
@@ -82,14 +82,16 @@ def test_search(browser, server, lang, regex):
 
 @pytest.mark.parametrize('lang', ['en', 'es', 'fr'])
 def test_community_extensions(browser, server, lang):
+    url = 'https://raw.githubusercontent.com/open-contracting/ocds_budget_breakdown_extension/master/extension.json'
+    extension = requests.get(url).json()
+
     browser.get('{}{}/extensions'.format(server, lang))
     community_extensions = browser.find_element_by_id('community-extensions').find_element_by_tag_name('table')
     # Currently community extensions aren't translated
-    link = community_extensions.find_element_by_link_text('Budget Breakdown')
-    assert (link.get_attribute('href') ==
-            'https://github.com/open-contracting/ocds_budget_breakdown_extension/blob/master/README.md')
+    link = community_extensions.find_element_by_link_text(extension['name']['en'])
+    assert (link.get_attribute('href') == extension['documentationUrl']['en'])
     cells = link.find_elements_by_xpath('../../td')
-    assert cells[2].text == 'For providing a detailed budget breakdown.'
+    assert cells[2].text == extension['description']['en']
     assert cells[3].text == 'ppp'
 
     assert 'ocds_budget_breakdown_extension' not in browser.find_element_by_id('using-extensions').text


### PR DESCRIPTION
In my local testing, all three Sphinx directives from sphinxcontrib-opencontracting continue to work after these changes, as does extensions.js, which adds community extensions to some tables created by those directives. `fetch_core_extensions.py` also produces the same results as before (with the exception of a small change to the Markdown template).

Once this PR is built, they can be tested at:

* http://standard.open-contracting.org/registry/en/schema/reference/#tender
* http://standard.open-contracting.org/registry/en/extensions/#community-extensions
* http://standard.open-contracting.org/registry/en/extensions/community/
* http://standard.open-contracting.org/registry/en/extensions/bids/#bid-statistics

Note that the documentation URLs for core extensions have changed, which should be corrected by closing https://github.com/open-contracting/ocds-extensions/issues/65