### PR TITLE
Remove reference to closed GitHub issue

### DIFF
--- a/standard/docs/en/schema/changelog.md
+++ b/standard/docs/en/schema/changelog.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Schema
 
 * [#712](https://github.com/open-contracting/standard/pull/712) Add missing titles for `publisher` and `url` and description for `record` in the record package schema, and missing description for `releases` in release package schema.
+* [#845](https://github.com/open-contracting/standard/pull/845) Remove reference to closed issue and note about field name.
 
 ### Documentation
 

--- a/standard/schema/record-package-schema.json
+++ b/standard/schema/record-package-schema.json
@@ -46,7 +46,7 @@
         },
         "uid": {
           "title": "uid",
-          "description": "The unique ID for this entity under the given ID scheme. Note the use of 'uid' rather than 'id'. See issue #245.",
+          "description": "The unique ID for this entity under the given ID scheme.",
           "type": [
             "string",
             "null"

--- a/standard/schema/release-package-schema.json
+++ b/standard/schema/release-package-schema.json
@@ -69,7 +69,7 @@
         },
         "uid": {
           "title": "uid",
-          "description": "The unique ID for this entity under the given ID scheme. Note the use of 'uid' rather than 'id'. See issue #245.",
+          "description": "The unique ID for this entity under the given ID scheme.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
closes #843

It's not clear to me that field descriptions need to draw attention to field names. (We can add a lot more based on common typos seen through data feedback reports, but I don't think it's the place of the schema to do this….)