### PR TITLE
Use consistent headings, order and style for changelog entries

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
+These release notes describe what's new in each version. OCDS adheres to [Semantic Versioning](https://semver.org/).
 
 ## Iterative improvements
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -15,8 +15,8 @@ Per the [normative and non-normative content and changes policy](https://docs.go
 * [#959](https://github.com/open-contracting/standard/pull/959) History section: Merge Credits and History of OCDS pages into Development and Appreciation page. Update history from present perspective.
 * [#908](https://github.com/open-contracting/standard/pull/908) Rename Validator to Data Review Tool.
 * [#975](https://github.com/open-contracting/standard/pull/975) Add a Make target to generate PDFs of the documentation.
-* Update the changelog [#932](https://github.com/open-contracting/standard/pull/932).
-* Build the documentation [#880](https://github.com/open-contracting/standard/pull/880) [#886](https://github.com/open-contracting/standard/pull/886) [#889](https://github.com/open-contracting/standard/pull/889) [#905](https://github.com/open-contracting/standard/pull/905) [#915](https://github.com/open-contracting/standard/pull/915) [#916](https://github.com/open-contracting/standard/pull/916) [#923](https://github.com/open-contracting/standard/pull/923) [#935](https://github.com/open-contracting/standard/pull/935) [#944](https://github.com/open-contracting/standard/pull/944) [#945](https://github.com/open-contracting/standard/pull/945) [#946](https://github.com/open-contracting/standard/pull/946) [#953](https://github.com/open-contracting/standard/pull/953) [#962](https://github.com/open-contracting/standard/pull/962).
+* Update the changelog [#932](https://github.com/open-contracting/standard/pull/932) [#976](https://github.com/open-contracting/standard/pull/976).
+* Make changes to how the documentation is built [#880](https://github.com/open-contracting/standard/pull/880) [#886](https://github.com/open-contracting/standard/pull/886) [#889](https://github.com/open-contracting/standard/pull/889) [#905](https://github.com/open-contracting/standard/pull/905) [#915](https://github.com/open-contracting/standard/pull/915) [#916](https://github.com/open-contracting/standard/pull/916) [#923](https://github.com/open-contracting/standard/pull/923) [#935](https://github.com/open-contracting/standard/pull/935) [#944](https://github.com/open-contracting/standard/pull/944) [#945](https://github.com/open-contracting/standard/pull/945) [#946](https://github.com/open-contracting/standard/pull/946) [#953](https://github.com/open-contracting/standard/pull/953) [#962](https://github.com/open-contracting/standard/pull/962) [#964](https://github.com/open-contracting/standard/pull/964).
 
 ## [1.1.4] - 2019-06-25
 
@@ -43,7 +43,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
 ### Codelists
 
 * [#824](https://github.com/open-contracting/standard/pull/824) Canonical codelist files are available at URLs like <https://standard.open-contracting.org/schema/1__1__4/codelists/>, and translations are available at URLs like <https://standard.open-contracting.org/1.1/en/codelists/>, for OCDS 1.1.4 and up.
-* [#746](https://github.com/open-contracting/standard/pull/746) [#842](https://github.com/open-contracting/standard/pull/842) Update currency codelist for ISO4217 amendments [166](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_166.pdf), [167](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_167.pdf), [168](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_168.pdf) and [169](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_169.pdf).
+* [#746](https://github.com/open-contracting/standard/pull/746) [#842](https://github.com/open-contracting/standard/pull/842) Update the currency codelist for ISO4217 amendments [166](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_166.pdf), [167](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_167.pdf), [168](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_168.pdf) and [169](https://www.currency-iso.org/dam/downloads/dl_currency_iso_amendment_169.pdf).
 * [#725](https://github.com/open-contracting/standard/pull/725) Add a 'plannedProcurementNotice' code to the `documentType` codelist, 'CUCOP' to `itemClassificationScheme`, 'interestedParty' to `partyRole`.
 * [#725](https://github.com/open-contracting/standard/pull/725) Update the descriptions of the 'tenderNotice' and 'technicalSpecifications' codes in the `documentType` codelist to align with the text of the [Agreement on Government Procurement (GPA)](https://www.wto.org/english/tratop_e/gproc_e/gp_gpa_e.htm) of the World Trade Organization (WTO).
 * [#725](https://github.com/open-contracting/standard/pull/725) Apply the style guide and OCDS glossary to the 'procuringEntity' and 'supplier' codes in the `partyRole` codelist.
@@ -88,7 +88,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * [#783](https://github.com/open-contracting/standard/pull/783) Community extensions relating to party details
   * [#837](https://github.com/open-contracting/standard/pull/837) OCDS profiles
 * Correct typos in the documentation [#692](https://github.com/open-contracting/standard/pull/692) [#713](https://github.com/open-contracting/standard/pull/713) [#719](https://github.com/open-contracting/standard/pull/719) [#726](https://github.com/open-contracting/standard/pull/726) [#732](https://github.com/open-contracting/standard/pull/732) [#752](https://github.com/open-contracting/standard/pull/752) [#756](https://github.com/open-contracting/standard/pull/756) [#795](https://github.com/open-contracting/standard/pull/795) [#867](https://github.com/open-contracting/standard/pull/867).
-* Improve the process to build the documentation [#666](https://github.com/open-contracting/standard/pull/666) [#698](https://github.com/open-contracting/standard/pull/698) [#708](https://github.com/open-contracting/standard/pull/708) [#709](https://github.com/open-contracting/standard/pull/709) [#721](https://github.com/open-contracting/standard/pull/721) [#724](https://github.com/open-contracting/standard/pull/724) [#727](https://github.com/open-contracting/standard/pull/727) [#729](https://github.com/open-contracting/standard/pull/729) [#733](https://github.com/open-contracting/standard/pull/733) [#740](https://github.com/open-contracting/standard/pull/740) [#747](https://github.com/open-contracting/standard/pull/747) [#753](https://github.com/open-contracting/standard/pull/753) [#762](https://github.com/open-contracting/standard/pull/762) [#767](https://github.com/open-contracting/standard/pull/767) [#783](https://github.com/open-contracting/standard/pull/783) [#787](https://github.com/open-contracting/standard/pull/787) [#796](https://github.com/open-contracting/standard/pull/796) [#813](https://github.com/open-contracting/standard/pull/813) [#836](https://github.com/open-contracting/standard/pull/836) [#875](https://github.com/open-contracting/standard/pull/875).
+* Make changes to how the documentation is built [#666](https://github.com/open-contracting/standard/pull/666) [#698](https://github.com/open-contracting/standard/pull/698) [#708](https://github.com/open-contracting/standard/pull/708) [#709](https://github.com/open-contracting/standard/pull/709) [#721](https://github.com/open-contracting/standard/pull/721) [#724](https://github.com/open-contracting/standard/pull/724) [#727](https://github.com/open-contracting/standard/pull/727) [#729](https://github.com/open-contracting/standard/pull/729) [#733](https://github.com/open-contracting/standard/pull/733) [#740](https://github.com/open-contracting/standard/pull/740) [#747](https://github.com/open-contracting/standard/pull/747) [#753](https://github.com/open-contracting/standard/pull/753) [#762](https://github.com/open-contracting/standard/pull/762) [#767](https://github.com/open-contracting/standard/pull/767) [#783](https://github.com/open-contracting/standard/pull/783) [#787](https://github.com/open-contracting/standard/pull/787) [#796](https://github.com/open-contracting/standard/pull/796) [#813](https://github.com/open-contracting/standard/pull/813) [#836](https://github.com/open-contracting/standard/pull/836) [#875](https://github.com/open-contracting/standard/pull/875).
 
 ### Extensions
 
@@ -103,61 +103,60 @@ See the changelogs for:
 
 ## [1.1.3] - 2018-04-16
 
-### Codelist updates
+### Bugs
 
-* Update currency codelist for ISO4217 amendment 165 (2017-12-14).
-
-### Schema fixes 
-
-* [#646](https://github.com/open-contracting/standard/pull/646) Disallow use of `null` as an item in the array for `Tender.additionalProcurementCategories`.
+* [#646](https://github.com/open-contracting/standard/pull/646) Disallow use of `null` as an entry in the array for `Tender.additionalProcurementCategories`.
 * [#639](https://github.com/open-contracting/standard/issues/639) Make `name` field optional for `OrganizationReference`.
-* [#630](https://github.com/open-contracting/standard/issues/630) Allow optional field `Item.unit` to be `null`.
-* [#603](https://github.com/open-contracting/standard/issues/603), [#645](https://github.com/open-contracting/standard/issues/645) Add definitions to Release, planning.budget, Milestone, Organization.address, Organization.contactPoint, Classification, Identifier, Value and Period.
-* Make `record-package-schema.json` use the `codelist` property to reference `releaseTag.csv`, and update the `enum` accordingly.
-* [#578](https://github.com/open-contracting/standard/issues/578) Update definition of `buyer` to cover goods, works and services, and multiple buyers.
+* [#630](https://github.com/open-contracting/standard/issues/630) Allow optional field `Item.unit` to be `null`. **(Reverted in 1.1.4)**
+* [a75c1c5](https://github.com/open-contracting/standard/pull/667/commits/a75c1c50379881f618df97ed3b9967297ed2edca) Make `record-package-schema.json` use the `codelist` property to reference `releaseTag.csv`, and update the `enum` accordingly.
 
-### Documentation fixes
+### Codelists
+
+* Update the currency codelist for ISO4217 amendment 165 (2017-12-14).
+
+### Schema
+
+* [#603](https://github.com/open-contracting/standard/issues/603), [#645](https://github.com/open-contracting/standard/issues/645) Add definitions to `Release`, `planning.budget`, `Milestone`, `Organization.address`, `Organization.contactPoint`, `Classification`, `Identifier`, `Value` and `Period`.
+* [#578](https://github.com/open-contracting/standard/issues/578) Update the definition of the `buyer` field to cover goods, works and services, and multiple buyers.
+
+### Documentation
 
 * [#633](https://github.com/open-contracting/standard/issues/633) Update schema reference page to display `Release.relatedProcesses`, `Planning.documents` and `Contract.relatedProcesses`.
 * [#634](https://github.com/open-contracting/standard/issues/634) Clarify definitions of core, community and local extensions.
+* Old and unused scripts have been removed from the documentation repository, and a number of script dependencies have been updated.
 
-### Extension fixes 
+### Extensions
 
 * [#40](https://github.com/open-contracting/ocds-extensions/issues/40), [#43](https://github.com/open-contracting/ocds-extensions/issues/43), [#47](https://github.com/open-contracting/ocds-extensions/issues/47) Add missing definitions, codelists and enums to core extensions, correct typos in codelist filenames, disallow use of `null` as an item in arrays, disallow required fields from being set to `null`, allow optional fields to be `null`, use `OrganizationReference` instead of `Organization`.
 
-Old and unused scripts have been removed from the documentation repository, and a number of script dependencies have been updated.
-
 ## [1.1.2] - 2017-11-10
 
-### Codelist updates
+### Codelists
 
-* [554](https://github.com/open-contracting/standard/issues/554) - **Update currency codelist for ISO4217 amendment 163 (2017-06-09)**. Note: XBT (Bitcoin) is removed from the codelist as it is not part of ISO4217.
+* [#554](https://github.com/open-contracting/standard/issues/554) Update the currency codelist for ISO4217 amendment 163 (2017-06-09). XBT (Bitcoin) is removed from the codelist as it is not part of ISO4217.
 
 ## [1.1.1] - 2017-07-31
 
-### Bug fixes
+### Bugs
 
-* [#482](https://github.com/open-contracting/standard/issues/482) **[Allow parties.role to be set to `null`](https://github.com/open-contracting/standard/pull/502/commits/475abf598063aae5c22e07baba015d960fcc3a95)** - required by the [merging approach](https://standard.open-contracting.org/1.1/en/schema/merging/). 
-* [#422](https://github.com/open-contracting/standard/issues/422) **[Including currency codelist in documentation and schema](https://standard.open-contracting.org/1.1/en/schema/codelists/#currency)** to support validation of currency values.
-* [#479](https://github.com/open-contracting/standard/issues/479) **[Fixing incorrect requirement to include releases in record-package-schema.json](https://standard.open-contracting.org/1.1/en/schema/record_package/)** 
-* [#475](https://github.com/open-contracting/standard/issues/475) **Adding enum arrays to all fields in the schema with a closed codelist** to support validation.
+* [#482](https://github.com/open-contracting/standard/issues/482) Allow optional field `parties.role` to be `null`.
+* [#479](https://github.com/open-contracting/standard/issues/479) Remove `releases` as a required field in [`record-package-schema.json`](https://standard.open-contracting.org/1.1/en/schema/record_package/).
+* [#475](https://github.com/open-contracting/standard/issues/475) Add an `enum` property to every field in the schema with a closed codelist.
 
-### Minor revisions
+### Codelists
 
-* [#471](https://github.com/open-contracting/standard/issues/471) **[Updating milestoneType codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#milestone-type)** replacing 'planning' with 'preProcurement' and 'adjudication' with 'assessment' and introducing codes for 'approval' and 'financing'. This is an open codelist, so previous codes remain valid, but publishers able to update to the new codes should do so. 
-* [#473](https://github.com/open-contracting/standard/issues/473) **[Updating definition of contractSchedule in documentType codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#document-type)**
+* [#422](https://github.com/open-contracting/standard/issues/422) Include a [currency codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#currency) in the documentation and schema.
+* [#471](https://github.com/open-contracting/standard/issues/471) Update the [milestoneType codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#milestone-type), replacing 'planning' with 'preProcurement' and 'adjudication' with 'assessment', and introducing 'approval' and 'financing'. This is an open codelist, so the old codes remain valid, but publishers able to update to the new codes should do so.
+* [#473](https://github.com/open-contracting/standard/issues/473) Update the definition of the 'contractSchedule' code in the [documentType codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#document-type).
 
-### Documentation improvements
+### Documentation
 
-* **Fixing typographic errors throughout the documentation and codelist descriptions**
-* [#480](https://github.com/open-contracting/standard/pull/480/commits/c3c41225639a06b0b0552016b32e2fe2e901a8fe) **[Updating basic, intermediate, advanced](https://standard.open-contracting.org/1.1/en/implementation/levels/) publication guidance** - to ensure tables and text are aligned. 
-* [#489](https://github.com/open-contracting/standard/issues/489) **Listing the milestone documents extension as a core extension** - and removing it from the community extensions list. This extension is only needed by publishers with legacy data containing documents at the milestone level.
-* [#493](https://github.com/open-contracting/standard/issues/493) **[Updating the description of the Organization Identifier Scheme codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#organization-identifier-scheme)** to reflect that the codelist is now maintained by [org-id.guide](http://www.org-id.guide/).
-
-### Code and build process
-
-* [#506](https://github.com/open-contracting/standard/issues/506) **Removed make_field_definitions.py** from utility scripts as it is no longer required.
-* **Addition of docstrings to key scripts**
+* [#480](https://github.com/open-contracting/standard/pull/480/commits/c3c41225639a06b0b0552016b32e2fe2e901a8fe) Align the tables and text in the [publication levels](https://standard.open-contracting.org/1.1/en/implementation/levels/) guidance.
+* [#489](https://github.com/open-contracting/standard/issues/489) Change the milestone documents extension to a core extension. This extension is only needed by publishers with legacy data containing documents within milestones.
+* [#493](https://github.com/open-contracting/standard/issues/493) Update the description of the [Organization Identifier Scheme codelist](https://standard.open-contracting.org/1.1/en/schema/codelists/#organization-identifier-scheme), to reflect that it is now maintained by [org-id.guide](http://www.org-id.guide/).
+* [#506](https://github.com/open-contracting/standard/issues/506) Remove `make_field_definitions.py` from the utility scripts, as it is no longer required.
+* Fix typographic errors throughout the documentation and codelist descriptions.
+* Add docstrings to utility scripts.
 
 ## [1.1.0] - 2017-05-01
 
@@ -204,7 +203,6 @@ Old and unused scripts have been removed from the documentation repository, and 
 * [#387](https://github.com/open-contracting/standard/issues/387) **[Codelist updates: Item Classification Scheme](https://standard.open-contracting.org/1.1/en/schema/codelists/#item-classification-scheme)** - New entries have been added to the itemClassificationScheme codelist
 * [#385](https://github.com/open-contracting/standard/issues/385) **[Codelist updates: awardCriteria](https://standard.open-contracting.org/1.1/en/schema/codelists/#award-criteria)** - Revising the awardCriteria codelist, with all existing codes deprecated and a new set of codes introduced. 
 
-
 ### Added
 
 * [#371](https://github.com/open-contracting/standard/issues/371) **[Linking related processes](https://standard.open-contracting.org/1.1/en/schema/reference/#relatedprocess)** - We have introduced a new RelatedProcess block at the release and contract level
@@ -234,47 +232,69 @@ Old and unused scripts have been removed from the documentation repository, and 
 
 ## [1.0.3] - 2017-07-31
 
-### Fixed
+### Bugs
 
-* [#329](https://github.com/open-contracting/standard/issues/329) - updated `item.quantity` to support decimal values (integer -> number)
-* [#253](https://github.com/open-contracting/standard/issues/253) - updated `value.amount` to support negative values
+* [#329](https://github.com/open-contracting/standard/issues/329) Update `Item.quantity` to allow decimal values.
+* [#253](https://github.com/open-contracting/standard/issues/253) Update `Value.amount` to allow negative values.
 
 ## [1.0.2] - 2016-11-22
 
-### Changed
+### Schema
 
-### Fixed
+* [#362](https://github.com/open-contracting/standard/issues/362) Add a `title` property to all fields.
+* [#221](https://github.com/open-contracting/standard/issues/221) Add the missing `procurementMethodDetails` field.
+* [#391](https://github.com/open-contracting/standard/issues/391) Fix typo in `description` property of `releaseTag` field.
+* [#271](https://github.com/open-contracting/standard/issues/271) Fix link to Fiscal Data Package.
+* [#314](https://github.com/open-contracting/standard/issues/314) Add a `description` property to the `numberOfTenderers` field.
+* [#244](https://github.com/open-contracting/standard/issues/244) Fix the `description` property of the `changes` field.
 
-- Added titles to all fields in the documentation (#362)
-- Missing field `procurementMethodDetails` added to schema (#221)
-- Typo fix in releaseTag (#391)
-- Fixing links to Fiscal Data Package (#271)
-- Description for `numberOfTenderers` (#314)
-- Fixed definition of `changes` (#244)
-- Updated documentation to refer to 'Object' not 'Reference' for fields (#228)
+### Documentation
 
-### Tidy up
-
-- Removed the old Spanish documentation translations folders from `standard/docs/es`
-- Added CSV download links for registered ocids, and publication levels
-- Updated publication levels spreadsheet to reflect version 1.0.2
+* [#228](https://github.com/open-contracting/standard/issues/228) Update the documentation to use "Object" not "Reference" in Format column of field tables.
+* Add CSV download links for registered ocids and publication levels.
+* Update the publication levels spreadsheet to reflect above changes.
+* Remove the old Spanish documentation translations from `standard/docs/es`.
 
 ## [1.0.1] - 2016-03-14
 
-Updated documentation was released. This did not make any semantic changes to the standard.
+### Bugs
 
-## [1.0] - 2015-07-29
+* [#300](https://github.com/open-contracting/standard/issues/300) Remove `"format": "uri"` from `publisher.scheme` field.
+* [#295](https://github.com/open-contracting/standard/issues/295) Allow optional fields `Award.status` and `Contract.status` to be `null`.
+* [#267](https://github.com/open-contracting/standard/issues/267) Rename codes in documentType codelist: 'Tender notice' to 'tenderNotice', 'Award notice' to 'awardNotice', 'Contract notice' to 'contractNotice'.
+* Fix bugs in versioned release schema.
 
-### Changed
+### Codelists
 
-- `contractPeriod` added to `award` to allow the anticipated period of a contract to be recorded, without requiring the creation of a contract block. Discussed in [#199](https://github.com/open-contracting/standard/issues/199)
+* Remove reference to non-existent `statusDescription` field in awardStatus codelist.
 
-- Updated codelists
+### Schema
 
-### Fixed
+* Add or update `title` and `description` properties.
+* [#283](https://github.com/open-contracting/standard/issues/283) Remove `"mergeStrategy": "ocdsVersion"` from `planning.budget` field.
 
-- Minor documentation fixes.
+### Documentation
+
+* Restructure the documentation, including: expanding Getting Started section, adding more examples.
+* Fix broken links.
+* Make changes to how the documentation is built, including: improving the translation process, adding some schema tests.
+
+## [1.0.0] - 2015-07-29
+
+### Codelists
+
+* Update `documentType` and `organizationIdentifierRegistrationAgency_iati` codelists.
+
+### Schema
+
+* [#199](https://github.com/open-contracting/standard/issues/199) Add the `Award.contractPeriod` field, to disclose the anticipated contract period without creating a `Contract` object.
+* Update the `description` property of the `Award.date` field.
+
+### Documentation
+
+* Fix typos in Markdown text and JSON examples.
+* Add changelog.
 
 ## [1.0.RC] - 2014-11-18
 
-Changes prior to this point are not covered by this changelog. A non-exhaustive overview of changes between the beta release and 1.0.RC can be [found on the project blog](https://www.open-contracting.org/2014/11/18/release-of-data-standard/).
+Changes prior to this release are not covered here. Please see the [overview of changes](https://www.open-contracting.org/2014/11/18/release-of-data-standard/) between the beta and 1.0.RC releases.

--- a/docs/history/history_and_development.md
+++ b/docs/history/history_and_development.md
@@ -1,28 +1,26 @@
 # Development and Appreciation
 
-The Open Contracting Data Standard is a core product of the [Open Contracting Partnership](https://www.open-contracting.org/) (OCP). Version 1.0 was developed for the OCP by the [World Wide Web Foundation](https://webfoundation.org/) and the [World Bank](https://www.worldbank.org/), through a project supported by the [Omidyar Network](https://www.omidyar.com) and the World Bank.
+Version 1.0.0 was developed for the [Open Contracting Partnership](https://www.open-contracting.org/) by the [World Wide Web Foundation](https://webfoundation.org/) and the [World Bank](https://www.worldbank.org/), through a project supported by the [Omidyar Network](https://www.omidyar.com) and the World Bank.
 
 ## Development
 
 ### Version 1.0.0
 
-The development of the 1.0 Release Candidate took place through a year-long process of supply and demand-side research, and open consultation, with reference to the [Principles for Digital Development](https://digitalprinciples.org/). The process included:
+The development of the 1.0 Release Candidate took place through a year-long process of supply-side and demand-side research, and open consultation, with reference to the [Principles for Digital Development](https://digitalprinciples.org/). The process included:
 
-* **Assessing data currently supplied through contract portals** - in order to understand the data that governments currently hold and publish, and how it is structured. To carry out this analysis we created the [Contracting Data Comparison tool](http://ocds.open-contracting.org/opendatacomparison/), and [mapped](http://ocds.open-contracting.org/opendatacomparison/datamap/) the fields of data available from a wide range of existing government contracting data portals around the world. 
-* **Exploring demand for contracting data** - through field work, interviews and online engagement with different communities and individuals who many use of contract information. The information needs of users were catalogued, and fed into the requirements for the specification structure and fields. We developed a series of priority use cases to guide implementation and adoption of the specification. [Read the demand-side assessment](https://docs.google.com/document/d/1zdgqSf-LUFVxO6Y_7v1cQf7l0vx35-p502jAI49JRmQ/edit).
-* **Iterative, open development** - we offered transparency, and gained broad feedback to improve the specification by offering early releases for comment ([alpha](https://standard.open-contracting.org/legacy/r/0__2__0/) and [beta](https://standard.open-contracting.org/legacy/r/0__3__2/)) and by maintaining a [public issue tracker](https://github.com/open-contracting/standard/issues). We engaged contracting, open-data, and other stakeholders through mailing lists and other online spaces. Finally, development sprints held at PyCon Montreal and PyCon Europe 2014 also actively contributed to the development of the specification. 
+* **Assessing the data supplied through contracting portals**, in order to understand what data governments published, and how it was structured. We created a [Contracting Data Comparison](http://ocds.open-contracting.org/opendatacomparison/) tool, which includes an analysis of the [distribution](http://ocds.open-contracting.org/opendatacomparison/datamap/) of fields used for common concepts by a wide range of government contracting data portals. [Read the supply-side assessment report](https://www.open-contracting.org/resources/supply-side-assessment-report/).
+* **Exploring demand for contracting data**, through field work, interviews and online engagement with different communities and individuals using contracting information. The information needs of users were organized into use cases, which informed the development of, and requirements for, the OCDS. [Read the demand-side assessment report](https://www.open-contracting.org/resources/demand-side-assessment-report/).
+* **Iterative, open development**. We received broad feedback on the [alpha](https://standard.open-contracting.org/legacy/r/0__2__0/) and [beta](https://standard.open-contracting.org/legacy/r/0__3__2/) releases. All issues were recorded and discussed in a public [issue tracker](https://github.com/open-contracting/standard/issues). We engaged public contracting, open data, and other stakeholders through mailing lists and other online spaces. Development sprints at PyCon Montreal and PyCon Europe 2014 also contributed to the development of the OCDS. Over 150 people provided comments, feedback and input over the year of initial development.
 
 The timeline of development was:
 
-* **research** (November 2013 - May 2014) - User requirements gathered, and existing data supply explored. Technical options for the specification considered and consulted on.
-* **alpha** (June 2014) - An [outline data model was shared](https://standard.open-contracting.org/legacy/r/0__2__0/), and high-level concepts outlined for consultation. Design of individual field-level specifications began.
-* **beta** (September 2014) - A proposed schema, including field-level definitions was put forward, and opened for consultation. Feedback suggested a number of substantial changes.
-* **release candidate** (November 2014) - The specification was released for final review.
-* **release** (July 2015) -  The initial version (1.0) was released with minor bug fixes.
+* **Research** (November 2013 to May 2014): User requirements were collected, and data supply was explored. Technical options for the OCDS were considered and consulted on.
+* **Alpha** (June 2014): An [outline data model](https://standard.open-contracting.org/legacy/r/0__2__0/) was shared, and high-level concepts were outlined for consultation. The design of individual fields was started.
+* **Beta** (September 2014): A schema, including field definitions, was proposed and opened for consultation. The feedback received motivated many substantial changes.
+* **Release candidate** (November 2014): The OCDS was released for final review.
+* **Release** (July 2015): Version 1.0.0 was released, with minor bug fixes.
 
-Over 150 people provided comments, feedback and input into the specification over the year of initial development.
-
-A number of older tools, created during the development of the standard, can be found in the [Open Contracting Archive GitHub organization](https://github.com/open-contracting-archive).
+A number of older tools, created during the development of the OCDS, can be found in the [Open Contracting Archive GitHub organization](https://github.com/open-contracting-archive).
 
 ### Upgrade history
 
@@ -30,7 +28,7 @@ A number of older tools, created during the development of the standard, can be 
 
 ## Appreciation
 
-The Open Contracting Data Standards has been developed with the input of many people. We extend our thanks to all the following who have given feedback and input over the course of the initial development project.
+The OCDS was developed with input from many people, to whom we extend our thanks.
 
 ### Core team
 
@@ -38,11 +36,11 @@ Core contributors (Version 1.1.0): Tim Davies, Duncan Dewhurst, David Raznick, L
 
 Core contributors (Version 1.0.1): Tim Davies, Lindsey Marchessault, Ben Webb, David Raznick, David Carpenter, Edafe Onerhime, Steven Flower.
 
-Lead authors (Version 1.0): [Tim Davies](http://www.timdavies.org.uk) ([Web Foundation](http://www.webfoundation.org)) & Sarah Bird ([Aptivate](http://aptivate.org)), with core input from: James McKinney ([Open North](http://opennorth.ca/)), Lindsey Marchessault ([World Bank](http://www.worldbank.org)), Marcela Rozo ([World Bank](http://www.worldbank.org)), Stephen Davenport ([World Bank](http://www.worldbank.org)), Ana Brandusescu, Jose M. Alonso ([Web Foundation](http://www.webfoundation.org)) and Michael Roberts ([Web Foundation](http://www.webfoundation.org)). 
+Lead authors (Version 1.0.0): [Tim Davies](http://www.timdavies.org.uk) ([Web Foundation](http://www.webfoundation.org)) & Sarah Bird ([Aptivate](http://aptivate.org)), with core input from: James McKinney ([Open North](http://opennorth.ca/)), Lindsey Marchessault ([World Bank](http://www.worldbank.org)), Marcela Rozo ([World Bank](http://www.worldbank.org)), Stephen Davenport ([World Bank](http://www.worldbank.org)), Ana Brandusescu, Jose M. Alonso ([Web Foundation](http://www.webfoundation.org)) and Michael Roberts ([Web Foundation](http://www.webfoundation.org)). 
 
 ### Contributors
 
-Many more people have been involved in inputting to the standard. Below is a non-exhaustive list of some of those people. Inclusion here is to extend our thanks. It does not imply endorsement by any of those included of the standard. 
+The use of a name does not imply any endorsement of the OCDS.
 
 #### Version 1.1.0
 
@@ -50,23 +48,25 @@ Issue contributors:
 
 [@agm3dc](https://github.com/agm3dc) (Andrew
 Mandelbaum), [@AlCollier](https://github.com/AlCollier) (Al Collier), [@andrewlorien](https://github.com/andrewlorien) (Andrew Lorien), [@Bjwebb](https://github.com/Bjwebb) (Ben Webb), [@chriscrownagents](https://github.com/chriscrownagents) (Chris Smith), [@ColinMaudry](https://github.com/ColinMaudry) (Colin Maudry), [@duncandewhurst](https://github.com/duncandewhurst) (Duncan Dewhurst), [@ec-mcs](https://github.com/ec-mcs) (Marc Christopher Schmidt), [@edugomez](https://github.com/edugomez) (Eduardo Gomez), [@ekoner](https://github.com/ekoner) (Edafe Onerhime), [@hrdwm14](https://github.com/hrdwm14), [@joshuacpowell](https://github.com/joshuacpowell) (Joshua Powell), [@jskuhrovec](https://github.com/jskuhrovec) (Jiri Skuhrovec), [@kindly](https://github.com/kindly) (David Raznick), [@KrzysztofMadejski](https://github.com/KrzysztofMadejski) (Krzysiek Madejski), [@LindseyAM](https://github.com/LindseyAM) (Lindsey Marchessault), [@myroslav](https://github.com/myroslav) (Myroslav Opyr), [@robredpath](https://github.com/robredpath) (Rob Redpath), [@SamCCSI](https://github.com/SamCCSI) (Sam
-Szoke-Burke), [@siwhitehouse](https://github.com/siwhitehouse) (Simon Whitehouse) and [@woodbine](https://github.com/woodbine)  (Ian Makgill).
+Szoke-Burke), [@siwhitehouse](https://github.com/siwhitehouse) (Simon Whitehouse) and [@woodbine](https://github.com/woodbine) (Ian Makgill).
 
 Peer reviewers:
 
 * Andrew Lorien, The Gruden Group (Australia)
-* Mireille Raad, World Bank (USA)
+* Mireille Raad, World Bank (United States)
 * Aura Martínez, Secretaría de Hacienda y Crédito Público (Mexico)
-* Andrew Mandelbaum & Mihai Postelnicu, Development Gateway (USA)
+* Andrew Mandelbaum & Mihai Postelnicu, Development Gateway (United States)
 * Patrick Enaholo, Pan Atlantic University - Lagos (Nigeria)
-* Juan Pane, Latin America Open Data Initiative  (Paraguay)
+* Juan Pane, Latin America Open Data Initiative (Paraguay)
 * Jachym Hercher, European Commission (Belgium)
 * Irum Maqsood, Public Works and Government Services Canada (Canada)
 
 #### Version 1.0.0
 
-Standard website design and icons by Neontribe: with thanks to Harry Harold and Heydon Pickering.
+Thanks for contributions to technical and policy development go to: Noé Domínguez, Oscar Montiel, Laura Serghi, Mathieu Leduc-Hamel, Michael Lenczner, Isabel Munilla, John Hawkins, Laura Bacon and Owen Scott.
 
-Thanks to Noé Domínguez , Oscar Montiel, Laura Serghi, Mathieu Leduc-Hamel, Michael Lenczner, Isabel Munilla, John Hawkins, Laura Bacon and Owen Scott for inputs into technical and policy development.
+Thanks for contributions to user research go to: Antonio Acuna, Steve Addler, Ivan Begtin, Bibhusan Bista, Eduardo Bohórquez, Mathieu Carlier, Andrew Clarke, Kami Dar, Eva Vozárová, Kami Dar, Daniel Dudis, Mihály Fazekas, Dustin Homer, John Jordan, Jeff Kaplan, Charles Kenny, Ian Makgill, Habibullah Muqbel, Seember Nyager, Meike Paetzold, Pascal Robichaud, Claire Schouten, Tom Sisti, and Chris Taggart.
 
-Many thanks also to those who contributed to the user research: Antonio Acuna, Steve Addler, Ivan Begtin, Bibhusan Bista, Eduardo Bohórquez, Mathieu Carlier, Andrew Clarke, Kami Dar, Eva Vozárová,  Kami Dar, Daniel Dudis, Mihály Fazekas, Dustin Homer, John Jordan, Jeff Kaplan, Charles Kenny, Ian Makgill, Habibullah Muqbel, Seember Nyager, Meike Paetzold, Pascal Robichaud, Claire Schouten, Tom Sisti; Chris Taggart; as well as all those who participated in Open Contracting Data related events and meetings in Montreal, Washington, Berlin, Kathmandu, Mexico, and online; and all those who wished to remain anonymous; for their invaluable input and feedback into the demand assessment process.
+Thanks to participants of open contracting data-related events and meetings in Montreal, Washington, Berlin, Kathmandu, Mexico and online, and all those who wished to remain anonymous, for their input and feedback into the demand-side assessment process.
+
+Standard website design and icons by Neontribe, with thanks to Harry Harold and Heydon Pickering.

--- a/docs/history/index.md
+++ b/docs/history/index.md
@@ -1,11 +1,13 @@
 # History
 
+The [Changelog](changelog) describes what's new in each version of OCDS. [Development and Appreciation](history_and_development) describes the development of early versions of OCDS, and thanks all contributors.
+
 ```eval_rst
 .. toctree::
    :maxdepth: 2
    :glob:
+   :hidden:
 
    changelog
    history_and_development
-
 ```


### PR DESCRIPTION
… except 1.1.0 (too long). Fill in 1.0.1 and 1.0.0 changelog entries.