### PR TITLE
Adding publication plan subheading to design stage

### DIFF
--- a/docs/guidance/design.md
+++ b/docs/guidance/design.md
@@ -8,6 +8,7 @@ On this page, you will find guidance on how to:
 * Set up your team
 * Build buy-in
 * Understand your context
+* Understand your key decisions and publication goals
 * Include OCDS in requirements for software developers and technical consultants
 
 ```eval_rst
@@ -28,7 +29,7 @@ The answers to these questions will help you to develop a robust publication pla
 
 **Resource**: [Methodology for Open Contracting Scoping Studies](https://www.open-contracting.org/resources/methodology-open-contracting-scoping-studies/)
 
-**Resource:** [Publication Plan Template](https://www.open-contracting.org/resources/ocds-publication-plan-template/)
+**Action:** Develop your [publication plan](#develop-your-publication-plan)
 
 If your contracting data is mostly on paper, in local spreadsheets or in unstructured electronic documents, and you don’t have the capacity to create a new IT system to collect data, consider reusing one of the existing [tools for collecting OCDS data](build/data_collection_tools).
 
@@ -66,7 +67,7 @@ Consult stakeholders early in the design of your OCDS implementation to identify
 
 **Action:** Identify your stakeholders and their use cases.
 
-**Action:** Document your stakeholders and goals in your [publication plan](https://www.open-contracting.org/resources/ocds-publication-plan-template/).
+**Action:** Document your stakeholders and goals in your [publication plan](#develop-your-publication-plan).
 
 ## Build your team
 
@@ -88,6 +89,17 @@ To achieve success, an OCDS implementation team ought to include the following r
 **Action:** [Contact the OCDS Helpdesk](../../support/index) to arrange an online introductory training for your technical team, in English or Spanish.
 
 **Action:** [Join the OCDS discussion group](../../support/index) to keep up to date and engage with other implementers.
+
+## Develop your publication plan
+
+A publication plan is a useful resource when you need to:
+
+* Present a summary of your OCDS mapping to key stakeholders;
+* Confirm shared understanding of key decisions and publication priorities across an open contracting project team;
+* Set out the goals that you will measure data publication against;
+* Access in-depth support from the OCDS Helpdesk. A clear publication plan will assist the helpdesk in providing the most relevant input.
+
+**Resource:** [OCDS Publication Plan Template](https://www.open-contracting.org/resources/ocds-publication-plan-template/)
 
 ## Writing OCDS requirements for eGP developers
 


### PR DESCRIPTION
Adding a 'publication plan' sub-heading to the design stage as per #1009, updated links within design stage. If this looks okay, I'll then update the 'publication plan' links in the other stages to point to this subheading. 