### PR TITLE
Disable smartquotes because it works incorrectly in French (changing …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ html_static_path = ['_static']
 # -- Local configuration -----------------------------------------------------
 
 repository_url = 'https://github.com/open-contracting/standard'
+smartquotes = False
 
 html_theme_options = {
     'display_version': True,


### PR DESCRIPTION
…single quote to double quote)

Example: https://standard.open-contracting.org/latest/fr/schema/identifiers/#types-of-identifiers