### PR TITLE
Add Tender.selectionCriteria

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -94,7 +94,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
 * [#969](https://github.com/open-contracting/standard/pull/969) Clarify the instruction for setting the `Unit.id` field.
 * [#995](https://github.com/open-contracting/standard/pull/995) Clarify the instruction for setting the `Release.date` field.
 * [#996](https://github.com/open-contracting/standard/pull/996) Fix a typo in the `versionedRelease` field.
-* [#1072](https://github.com/open-contracting/standard/pull/1072) Add `Tender.selectionCriteria`, clarify the description of `Tender.eligibilityCriteria`
+* [#1237](https://github.com/open-contracting/standard/pull/1237) Add `Tender.selectionCriteria`.
 
 ### Documentation
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -94,6 +94,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
 * [#969](https://github.com/open-contracting/standard/pull/969) Clarify the instruction for setting the `Unit.id` field.
 * [#995](https://github.com/open-contracting/standard/pull/995) Clarify the instruction for setting the `Release.date` field.
 * [#996](https://github.com/open-contracting/standard/pull/996) Fix a typo in the `versionedRelease` field.
+* [#1072](https://github.com/open-contracting/standard/pull/1072) Add `Tender.selectionCriteria`, clarify the description of `Tender.eligibilityCriteria`
 
 ### Documentation
 

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -3112,7 +3112,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"
@@ -11550,7 +11550,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -3110,6 +3110,14 @@
             "null"
           ]
         },
+        "selectionCriteria": {
+          "title": "Selection criteria",
+          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "awardPeriod": {
           "title": "Period",
           "description": "Key events during a contracting process may have a known start date, end date, duration, or maximum extent (the latest date the period can extend to). In some cases, not all of these fields will have known or relevant values.",
@@ -4017,6 +4025,12 @@
           ]
         },
         "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "^(selectionCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"
@@ -11534,6 +11548,14 @@
             "null"
           ]
         },
+        "selectionCriteria": {
+          "title": "Selection criteria",
+          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "awardPeriod": {
           "title": "Period",
           "description": "Key events during a contracting process may have a known start date, end date, duration, or maximum extent (the latest date the period can extend to). In some cases, not all of these fields will have known or relevant values.",
@@ -12441,6 +12463,12 @@
           ]
         },
         "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "^(selectionCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -3112,7 +3112,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"
@@ -11550,7 +11550,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -3112,7 +3112,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements for tenderers to participate in the contracting process. Selection criteria ensure that a tenderer has the legal and financial capacities and the technical and professional abilities to perform the contract to be awarded. More structured information can be provided using the selection criteria extension.",
           "type": [
             "string",
             "null"
@@ -11550,7 +11550,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements for tenderers to participate in the contracting process. Selection criteria ensure that a tenderer has the legal and financial capacities and the technical and professional abilities to perform the contract to be awarded. More structured information can be provided using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -395,6 +395,14 @@
             "null"
           ]
         },
+        "selectionCriteria": {
+          "title": "Selection criteria",
+          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "awardPeriod": {
           "title": "Evaluation and award period",
           "description": "The period for decision making regarding the contract award. The end date should be the date on which an award decision is due to be finalized. The start date may be used to indicate the start of an evaluation period.",
@@ -488,6 +496,12 @@
           ]
         },
         "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "^(selectionCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -395,9 +395,10 @@
             "null"
           ]
         },
+
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "A description of any selection criteria for potential suppliers. For example, a supplier might need to prove a certain professional ability, enrollment in a particular trade register or a minimum financial standing. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -395,7 +395,6 @@
             "null"
           ]
         },
-
         "selectionCriteria": {
           "title": "Selection criteria",
           "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -397,7 +397,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements for tenderers to participate in the contracting process. Selection criteria ensure that a tenderer has the legal and financial capacities and the technical and professional abilities to perform the contract to be awarded. More structured information can be provided using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -397,7 +397,7 @@
         },
         "selectionCriteria": {
           "title": "Selection criteria",
-          "description": "The minimum requirements that the tenderers must meet to be selected. Selection criteria may assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
+          "description": "The minimum requirements that the tenderers need to meet to be selected. Selection criteria can assess several aspects of the tenderers: professional ability, financial standing, quality management procedures, or any other aspect deemed relevant to prove their ability to provide the procured goods or services. More structured information can be provided on selection criteria using the selection criteria extension.",
           "type": [
             "string",
             "null"

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -429,6 +429,9 @@
         "eligibilityCriteria": {
           "$ref": "#/definitions/StringNullVersioned"
         },
+        "selectionCriteria": {
+          "$ref": "#/definitions/StringNullVersioned"
+        },
         "awardPeriod": {
           "$ref": "#/definitions/Period"
         },
@@ -527,6 +530,12 @@
           ]
         },
         "^(eligibilityCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "^(selectionCriteria_(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)))$": {
           "type": [
             "string",
             "null"


### PR DESCRIPTION
Since we found no proof that there is a requirement for the support of a mixed (selection criteria + exclusion grounds) approach, I move on with the addition of `Tender.selectionCriteria` (cf https://github.com/open-contracting/standard/issues/1120#issuecomment-729127826 and below)

Closes #1120 