### PR TITLE
release and record packages schemas: remove minItems

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -161,6 +161,10 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * [#1241](https://github.com/open-contracting/standard/pull/1241) Align descriptions of `Record` `releases`, linked releases and embedded releases.
   * [#1307](https://github.com/open-contracting/standard/pull/1307) Clarify uniqueness rules for records.
   * [#1339](https://github.com/open-contracting/standard/pull/1339) Deprecate `packages`.
+  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `records.minItems` requirement
+ 
+* Release package schema:
+  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `releases.minItems` requirement
 
 * Improve the clarity of field descriptions in the release package schema and record package schema:
   * [#1067](https://github.com/open-contracting/standard/pull/1067) `Publisher.name`, to indicate that it is the organization or department responsible for publishing the OCDS version of the data.

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -161,10 +161,10 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * [#1241](https://github.com/open-contracting/standard/pull/1241) Align descriptions of `Record` `releases`, linked releases and embedded releases.
   * [#1307](https://github.com/open-contracting/standard/pull/1307) Clarify uniqueness rules for records.
   * [#1339](https://github.com/open-contracting/standard/pull/1339) Deprecate `packages`.
-  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `records.minItems` requirement
+  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `records.minItems` requirement.
  
 * Release package schema:
-  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `releases.minItems` requirement
+  * [#1374](https://github.com/open-contracting/standard/pull/1374) Remove `releases.minItems` requirement.
 
 * Improve the clarity of field descriptions in the release package schema and record package schema:
   * [#1067](https://github.com/open-contracting/standard/pull/1067) `Publisher.name`, to indicate that it is the organization or department responsible for publishing the OCDS version of the data.

--- a/schema/record-package-schema.json
+++ b/schema/record-package-schema.json
@@ -109,7 +109,6 @@
       "title": "Records",
       "description": "The records for this data package.",
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "#/definitions/Record"
       },

--- a/schema/release-package-schema.json
+++ b/schema/release-package-schema.json
@@ -43,7 +43,6 @@
       "title": "Releases",
       "description": "An array of one or more OCDS releases.",
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "https://standard.open-contracting.org/schema/1__1__5/release-schema.json"
       },


### PR DESCRIPTION
Closes #419 
I'm not sure if we should also update the guidance on releases and record packages to mention when the list could be empty.