### PR TITLE
Remove deprecated fields from examples

### DIFF
--- a/docs/_static/json/amendments/amendments-contract-example.json
+++ b/docs/_static/json/amendments/amendments-contract-example.json
@@ -6,10 +6,6 @@
   "publishedDate": "2019-02-17T00:00:00Z",
   "license": "https://creativecommons.org/licenses/by/3.0/au/",
   "version": "1.1",
-  "packages": [
-    "https://standard.open-contracting.org/examples/releases/ocds-d2phr6-12b0ab8ac4c28d322a82062e99918856-9887f9ebe7043172ab2abe4db2a5aa24",
-    "https://standard.open-contracting.org/examples/releases/ocds-d2phr6-12b0ab8ac4c28d322a82062e99918856-2000b475e7c23fcda74fcae13275e6c5"
-  ],
   "records": [
     {
       "ocid": "ocds-d2phr6-12b0ab8ac4c28d322a82062e99918856",
@@ -73,7 +69,7 @@
               ],
               "address": {
                 "postalCode": "4870",
-                "countryName": "AUSTRALIA",
+                "country": "AU",
                 "region": "QLD",
                 "locality": "PORTSMITH"
               },
@@ -159,7 +155,7 @@
               ],
               "address": {
                 "postalCode": "4870",
-                "countryName": "AUSTRALIA",
+                "country": "AU",
                 "region": "QLD",
                 "locality": "PORTSMITH"
               },
@@ -265,7 +261,7 @@
             ],
             "address": {
               "postalCode": "4870",
-              "countryName": "AUSTRALIA",
+              "country": "AU",
               "region": "QLD",
               "locality": "PORTSMITH"
             },
@@ -660,14 +656,14 @@
                   "value": "4870"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-d2phr6-12b0ab8ac4c28d322a82062e99918856-9887f9ebe7043172ab2abe4db2a5aa24",
                   "releaseDate": "2019-02-15T01:00:58Z",
                   "releaseTag": [
                     "contract"
                   ],
-                  "value": "AUSTRALIA"
+                  "value": "AU"
                 }
               ],
               "region": [

--- a/docs/_static/json/amendments/amendments-easy-releases-example.json
+++ b/docs/_static/json/amendments/amendments-easy-releases-example.json
@@ -6,9 +6,6 @@
   "publishedDate": "",
   "license": "https://creativecommons.org/licenses/by/3.0/au/",
   "version": "1.1",
-  "packages": [
-    "https://standard.open-contracting.org/examples/release-packages/ocds-d2phr6-1000035663"
-  ],
   "records": [
     {
       "ocid": "ocds-d2phr6-1000035663",
@@ -33,7 +30,7 @@
               ],
               "address": {
                 "postalCode": "2600",
-                "countryName": "AUSTRALIA",
+                "country": "AU",
                 "region": "ACT",
                 "streetAddress": "JOHN GORTON BUILDING, KING EDWARD TERRACE, PARKES",
                 "locality": "CANBERRA"
@@ -113,7 +110,7 @@
               ],
               "address": {
                 "postalCode": "2600",
-                "countryName": "AUSTRALIA",
+                "country": "AU",
                 "region": "ACT",
                 "streetAddress": "JOHN GORTON BUILDING, KING EDWARD TERRACE, PARKES",
                 "locality": "CANBERRA"
@@ -195,7 +192,7 @@
             ],
             "address": {
               "postalCode": "2600",
-              "countryName": "AUSTRALIA",
+              "country": "AU",
               "region": "ACT",
               "streetAddress": "JOHN GORTON BUILDING, KING EDWARD TERRACE, PARKES",
               "locality": "CANBERRA"
@@ -355,14 +352,14 @@
                   "value": "2600"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-d2phr6-1000035663-tender-2015-04-04T00:00:00Z",
                   "releaseDate": "2015-04-04T00:00:00Z",
                   "releaseTag": [
                     "tender"
                   ],
-                  "value": "AUSTRALIA"
+                  "value": "AU"
                 }
               ],
               "region": [

--- a/docs/_static/json/amendments/amendments-tender-example.json
+++ b/docs/_static/json/amendments/amendments-tender-example.json
@@ -10,11 +10,6 @@
   "license": "http://opendatacommons.org/licenses/pddl/1.0/",
   "publicationPolicy": "https://github.com/open-contracting/sample-data/",
   "version": "1.1",
-  "packages": [
-    "https://standard.open-contracting.org/examples/releases/ocds-213czf-000-00002-01-tender.json",
-    "https://standard.open-contracting.org/examples/releases/ocds-213czf-000-00002-01-tender-update.json",
-    "https://standard.open-contracting.org/examples/releases/ocds-213czf-000-00002-01-tender-amendment.json"
-  ],
   "records": [
     {
       "ocid": "ocds-213czf-000-00002",
@@ -58,9 +53,6 @@
             },
             "procurementMethod": "open",
             "awardCriteria": "bestProposal",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "tenderPeriod": {
               "startDate": "2016-01-31T09:00:00Z",
               "endDate": "2016-02-15T18:00:00Z"
@@ -110,9 +102,6 @@
             },
             "procurementMethod": "open",
             "awardCriteria": "bestProposal",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "tenderPeriod": {
               "startDate": "2016-01-31T09:00:00Z",
               "endDate": "2016-02-15T18:00:00Z"
@@ -162,9 +151,6 @@
             },
             "procurementMethod": "open",
             "awardCriteria": "bestProposal",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "tenderPeriod": {
               "startDate": "2016-01-31T09:00:00Z",
               "endDate": "2016-02-20T18:00:00Z"
@@ -224,9 +210,6 @@
           },
           "procurementMethod": "open",
           "awardCriteria": "bestProposal",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "tenderPeriod": {
             "startDate": "2016-01-31T09:00:00Z",
             "endDate": "2016-02-20T18:00:00Z"
@@ -456,18 +439,6 @@
                 "tender"
               ],
               "value": "bestProposal"
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00002-01-tender",
-              "releaseDate": "2016-01-01T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
-              ]
             }
           ],
           "tenderPeriod": {

--- a/docs/examples/award.json
+++ b/docs/examples/award.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "E14 5HU",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",
@@ -131,9 +131,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/contract.json
+++ b/docs/examples/contract.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "E14 5HU",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",

--- a/docs/examples/contractAmendment.json
+++ b/docs/examples/contractAmendment.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "E14 5HU",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",

--- a/docs/examples/extended.json
+++ b/docs/examples/extended.json
@@ -37,7 +37,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -124,9 +124,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/implementation.json
+++ b/docs/examples/implementation.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "E14 5HU",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",

--- a/docs/examples/merging/example02-field-planning.json
+++ b/docs/examples/merging/example02-field-planning.json
@@ -23,7 +23,7 @@
             "buyer"
           ],
           "address": {
-            "countryName": "COLOMBIA",
+            "country": "CO",
             "region": "Bogotá D.C.",
             "streetAddress": "Calle 26 No. 27-48",
             "locality": "Bogotá D.C."

--- a/docs/examples/merging/example02-field-record.json
+++ b/docs/examples/merging/example02-field-record.json
@@ -26,7 +26,7 @@
                 "buyer"
               ],
               "address": {
-                "countryName": "COLOMBIA",
+                "country": "CO",
                 "region": "Bogotá D.C.",
                 "streetAddress": "Calle 26 No. 27-48",
                 "locality": "Bogotá D.C."
@@ -88,7 +88,7 @@
                 "buyer"
               ],
               "address": {
-                "countryName": "COLOMBIA",
+                "country": "CO",
                 "region": "Bogotá D.C.",
                 "streetAddress": "Calle 26 No. 27-48",
                 "locality": "Bogotá D.C."
@@ -129,9 +129,6 @@
             "value": {
               "amount": 6725000
             },
-            "submissionMethod": [
-              "inPerson"
-            ],
             "submissionMethodDetails": "Municipio obtención: Guayabal Municipio entrega: Guayabal Municipio ejecución: No definido Lugar aclaraciones: No definido",
             "procuringEntity": {
               "id": "800215546",
@@ -159,7 +156,7 @@
               "buyer"
             ],
             "address": {
-              "countryName": "COLOMBIA",
+              "country": "CO",
               "region": "Bogotá D.C.",
               "streetAddress": "Calle 26 No. 27-48",
               "locality": "Bogotá D.C."
@@ -203,9 +200,6 @@
           "value": {
             "amount": 6725000
           },
-          "submissionMethod": [
-            "inPerson"
-          ],
           "submissionMethodDetails": "Municipio obtención: Guayabal Municipio entrega: Guayabal Municipio ejecución: No definido Lugar aclaraciones: No definido"
         }
       },
@@ -258,14 +252,14 @@
               }
             ],
             "address": {
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "13-9-368828-planning",
                   "releaseDate": "2013-07-17T16:36:56.000Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "COLOMBIA"
+                  "value": "CO"
                 }
               ],
               "region": [
@@ -548,19 +542,6 @@
               }
             ]
           },
-          "submissionMethod": [
-            {
-              "releaseID": "13-9-368828-tender",
-              "releaseDate": "2013-07-17T16:36:56.000Z",
-              "releaseTag": [
-                "planningUpdate",
-                "tender"
-              ],
-              "value": [
-                "inPerson"
-              ]
-            }
-          ],
           "submissionMethodDetails": [
             {
               "releaseID": "13-9-368828-tender",

--- a/docs/examples/merging/example02-field-tender.json
+++ b/docs/examples/merging/example02-field-tender.json
@@ -24,7 +24,7 @@
             "buyer"
           ],
           "address": {
-            "countryName": "COLOMBIA",
+            "country": "CO",
             "region": "Bogotá D.C.",
             "streetAddress": "Calle 26 No. 27-48",
             "locality": "Bogotá D.C."
@@ -69,9 +69,6 @@
           "startDate": "2013-08-01T09:00:00.000Z",
           "durationInDays": 15
         },
-        "submissionMethod": [
-          "inPerson"
-        ],
         "submissionMethodDetails": "Municipio obtención: Guayabal Municipio entrega: Guayabal Municipio ejecución: No definido Lugar aclaraciones: No definido",
         "procuringEntity": {
           "id": "800215546",

--- a/docs/examples/merging/example02-object-record.json
+++ b/docs/examples/merging/example02-object-record.json
@@ -26,7 +26,7 @@
                 "buyer"
               ],
               "address": {
-                "countryName": "COLOMBIA",
+                "country": "CO",
                 "region": "Cauca",
                 "locality": "Mercaderes"
               },
@@ -57,9 +57,6 @@
             "value": {
               "amount": 5000000
             },
-            "submissionMethod": [
-              "inPerson"
-            ],
             "procuringEntity": {
               "id": "890701933",
               "name": "CAUCA - ALCALDÍA MUNICIPIO DE MERCADERES"
@@ -102,7 +99,7 @@
                 "buyer"
               ],
               "address": {
-                "countryName": "COLOMBIA",
+                "country": "CO",
                 "region": "Cauca",
                 "locality": "Mercaderes"
               },
@@ -133,9 +130,6 @@
             "value": {
               "amount": 5000000
             },
-            "submissionMethod": [
-              "inPerson"
-            ],
             "procuringEntity": {
               "id": "890701933",
               "name": "CAUCA - ALCALDÍA MUNICIPIO DE MERCADERES"
@@ -170,7 +164,7 @@
               "buyer"
             ],
             "address": {
-              "countryName": "COLOMBIA",
+              "country": "CO",
               "region": "Cauca",
               "locality": "Mercaderes"
             },
@@ -200,9 +194,6 @@
           "value": {
             "amount": 5000000
           },
-          "submissionMethod": [
-            "inPerson"
-          ],
           "procuringEntity": {
             "id": "890701933",
             "name": "CAUCA - ALCALDÍA MUNICIPIO DE MERCADERES"
@@ -274,14 +265,14 @@
               }
             ],
             "address": {
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "11-13-651832-tender",
                   "releaseDate": "2011-10-14T16:26:49.000Z",
                   "releaseTag": [
                     "tender"
                   ],
-                  "value": "COLOMBIA"
+                  "value": "CO"
                 }
               ],
               "region": [
@@ -466,18 +457,6 @@
               }
             ]
           },
-          "submissionMethod": [
-            {
-              "releaseID": "11-13-651832-tender",
-              "releaseDate": "2011-10-14T16:26:49.000Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "inPerson"
-              ]
-            }
-          ],
           "procuringEntity": {
             "id": [
               {

--- a/docs/examples/merging/example02-object-tender.json
+++ b/docs/examples/merging/example02-object-tender.json
@@ -23,7 +23,7 @@
             "buyer"
           ],
           "address": {
-            "countryName": "COLOMBIA",
+            "country": "CO",
             "region": "Cauca",
             "locality": "Mercaderes"
           },
@@ -54,9 +54,6 @@
         "value": {
           "amount": 5000000
         },
-        "submissionMethod": [
-          "inPerson"
-        ],
         "procuringEntity": {
           "id": "890701933",
           "name": "CAUCA - ALCALDÍA MUNICIPIO DE MERCADERES"

--- a/docs/examples/merging/example02-object-tenderAmendment.json
+++ b/docs/examples/merging/example02-object-tenderAmendment.json
@@ -23,7 +23,7 @@
             "buyer"
           ],
           "address": {
-            "countryName": "COLOMBIA",
+            "country": "CO",
             "region": "Cauca",
             "locality": "Mercaderes"
           },
@@ -54,9 +54,6 @@
         "value": {
           "amount": 5000000
         },
-        "submissionMethod": [
-          "inPerson"
-        ],
         "procuringEntity": {
           "id": "890701933",
           "name": "CAUCA - ALCALDÍA MUNICIPIO DE MERCADERES"

--- a/docs/examples/merging/example03-award.json
+++ b/docs/examples/merging/example03-award.json
@@ -32,7 +32,7 @@
           "name": "Zambia Telecommunications Company Limited",
           "address": {
             "postalCode": "37000",
-            "countryName": "Zambia",
+            "country": "ZM",
             "region": "ZM",
             "streetAddress": "Zamtel House, Corner Church and Chilubi Roads",
             "locality": "Lusaka"
@@ -55,7 +55,7 @@
           },
           "address": {
             "postalCode": "",
-            "countryName": "Zambia",
+            "country": "ZM",
             "region": "ZM",
             "streetAddress": "Plot 17 Chaholi Road Rhodes Park",
             "locality": "Lusaka"

--- a/docs/examples/merging/example03-awardAmendment.json
+++ b/docs/examples/merging/example03-awardAmendment.json
@@ -32,7 +32,7 @@
           "name": "Zambia Telecommunications Company Limited",
           "address": {
             "postalCode": "37000",
-            "countryName": "Zambia",
+            "country": "ZM",
             "region": "ZM",
             "streetAddress": "Zamtel House, Corner Church and Chilubi Roads",
             "locality": "Lusaka"
@@ -55,7 +55,7 @@
           },
           "address": {
             "postalCode": "",
-            "countryName": "Zambia",
+            "country": "ZM",
             "region": "ZM",
             "streetAddress": "Plot 17 Chaholi Road Rhodes Park",
             "locality": "Lusaka"

--- a/docs/examples/merging/example03-record.json
+++ b/docs/examples/merging/example03-record.json
@@ -35,7 +35,7 @@
               "name": "Zambia Telecommunications Company Limited",
               "address": {
                 "postalCode": "37000",
-                "countryName": "Zambia",
+                "country": "ZM",
                 "region": "ZM",
                 "streetAddress": "Zamtel House, Corner Church and Chilubi Roads",
                 "locality": "Lusaka"
@@ -58,7 +58,7 @@
               },
               "address": {
                 "postalCode": "",
-                "countryName": "Zambia",
+                "country": "ZM",
                 "region": "ZM",
                 "streetAddress": "Plot 17 Chaholi Road Rhodes Park",
                 "locality": "Lusaka"
@@ -206,7 +206,7 @@
               "name": "Zambia Telecommunications Company Limited",
               "address": {
                 "postalCode": "37000",
-                "countryName": "Zambia",
+                "country": "ZM",
                 "region": "ZM",
                 "streetAddress": "Zamtel House, Corner Church and Chilubi Roads",
                 "locality": "Lusaka"
@@ -229,7 +229,7 @@
               },
               "address": {
                 "postalCode": "",
-                "countryName": "Zambia",
+                "country": "ZM",
                 "region": "ZM",
                 "streetAddress": "Plot 17 Chaholi Road Rhodes Park",
                 "locality": "Lusaka"
@@ -344,7 +344,7 @@
             "name": "Zambia Telecommunications Company Limited",
             "address": {
               "postalCode": "37000",
-              "countryName": "Zambia",
+              "country": "ZM",
               "region": "ZM",
               "streetAddress": "Zamtel House, Corner Church and Chilubi Roads",
               "locality": "Lusaka"
@@ -367,7 +367,7 @@
             },
             "address": {
               "postalCode": "",
-              "countryName": "Zambia",
+              "country": "ZM",
               "region": "ZM",
               "streetAddress": "Plot 17 Chaholi Road Rhodes Park",
               "locality": "Lusaka"
@@ -601,14 +601,14 @@
                   "value": "37000"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-23g63a01-200502-award",
                   "releaseDate": "2018-12-31T23:00:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "Zambia"
+                  "value": "ZM"
                 }
               ],
               "region": [
@@ -732,14 +732,14 @@
                   "value": ""
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-23g63a01-200502-award",
                   "releaseDate": "2018-12-31T23:00:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "Zambia"
+                  "value": "ZM"
                 }
               ],
               "region": [

--- a/docs/examples/merging/merge-tender-1.json
+++ b/docs/examples/merging/merge-tender-1.json
@@ -51,9 +51,6 @@
         },
         "procurementMethod": "open",
         "awardCriteria": "bestProposal",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "tenderPeriod": {
           "startDate": "2016-01-31T09:00:00Z",
           "endDate": "2016-02-15T18:00:00Z"

--- a/docs/examples/merging/merge-tender-2.json
+++ b/docs/examples/merging/merge-tender-2.json
@@ -51,9 +51,6 @@
         },
         "procurementMethod": "open",
         "awardCriteria": "bestProposal",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "tenderPeriod": {
           "startDate": "2016-01-31T09:00:00Z",
           "endDate": "2016-02-15T18:00:00Z"

--- a/docs/examples/merging/merge-tender-3.json
+++ b/docs/examples/merging/merge-tender-3.json
@@ -51,9 +51,6 @@
         },
         "procurementMethod": "open",
         "awardCriteria": "bestProposal",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "tenderPeriod": {
           "startDate": "2016-01-31T09:00:00Z",
           "endDate": "2016-02-20T18:00:00Z"

--- a/docs/examples/merging/merged-tender.json
+++ b/docs/examples/merging/merged-tender.json
@@ -89,9 +89,6 @@
           },
           "procurementMethod": "open",
           "awardCriteria": "bestProposal",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "tenderPeriod": {
             "startDate": "2016-01-31T09:00:00Z",
             "endDate": "2016-02-20T18:00:00Z"

--- a/docs/examples/merging/merged.json
+++ b/docs/examples/merging/merged.json
@@ -89,9 +89,6 @@
           },
           "procurementMethod": "open",
           "awardCriteria": "bestProposal",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "tenderPeriod": {
             "startDate": "2016-01-31T09:00:00Z",
             "endDate": "2016-02-20T18:00:00Z"

--- a/docs/examples/merging/versioned.json
+++ b/docs/examples/merging/versioned.json
@@ -89,9 +89,6 @@
           },
           "procurementMethod": "open",
           "awardCriteria": "bestProposal",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "tenderPeriod": {
             "startDate": "2016-01-31T09:00:00Z",
             "endDate": "2016-02-20T18:00:00Z"
@@ -345,18 +342,6 @@
                 "tender"
               ],
               "value": "bestProposal"
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00002-01-tender",
-              "releaseDate": "2016-01-01T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
-              ]
             }
           ],
           "tenderPeriod": {

--- a/docs/examples/milestones/af-implementation-milestones-3.json
+++ b/docs/examples/milestones/af-implementation-milestones-3.json
@@ -108,7 +108,7 @@
             "payer"
           ],
           "address": {
-            "countryName": "افغانستان",
+            "country": "AF",
             "region": "مرکز"
           },
           "identifier": {

--- a/docs/examples/minimal_updates/award.json
+++ b/docs/examples/minimal_updates/award.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "Anytown",
             "region": "AnyCounty",
             "postalCode": "AN1 1TN",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",

--- a/docs/examples/minimal_updates/tender.json
+++ b/docs/examples/minimal_updates/tender.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -100,9 +100,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/minimal_updates/tenderUpdate.json
+++ b/docs/examples/minimal_updates/tenderUpdate.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",

--- a/docs/examples/organization-classification/dhangadhi_female_chaired_example.json
+++ b/docs/examples/organization-classification/dhangadhi_female_chaired_example.json
@@ -34,7 +34,7 @@
           },
           "address": {
             "streetAddress": "धनगढी ११",
-            "countryName": "Nepal"
+            "country": "NP"
           }
         }
       ],

--- a/docs/examples/organization-classification/moldova_organization_scale.json
+++ b/docs/examples/organization-classification/moldova_organization_scale.json
@@ -43,9 +43,6 @@
         "description": "Ofertanții au solicitat lucrări pentru construirea de noi biciclete în centrul orașului.",
         "status": "complete",
         "hasEnquiries": false,
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Lista platformelor: achizitii, ebs, licitatie, yptender",
         "tenderers": [
           {

--- a/docs/examples/organization-classification/uk_organization_classification.json
+++ b/docs/examples/organization-classification/uk_organization_classification.json
@@ -61,7 +61,7 @@
             "locality": "Wood Green",
             "region": "UKG13",
             "postalCode": "N22 8LE",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "url": "http://www.haringey.gov.uk"

--- a/docs/examples/organization-identifiers.json
+++ b/docs/examples/organization-identifiers.json
@@ -34,7 +34,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -68,7 +68,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "SE1 9PZ",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Contracts Team",

--- a/docs/examples/organization-personal-identifier.json
+++ b/docs/examples/organization-personal-identifier.json
@@ -89,9 +89,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/organizational-units/honduras-planning.json
+++ b/docs/examples/organizational-units/honduras-planning.json
@@ -27,7 +27,7 @@
             "region": "Francisco Morazan",
             "streetAddress": "Ave. Los Proceseres",
             "locality": "Tegucigalpa",
-            "countryName": "Honduras"
+            "country": "HN"
           },
           "contactPoint": {
             "telephone": "236-5786",

--- a/docs/examples/organizational-units/moldova-tender.json
+++ b/docs/examples/organizational-units/moldova-tender.json
@@ -54,7 +54,6 @@
         "procurementMethod": "open",
         "mainProcurementCategory": "goods",
         "hasEnquiries": false,
-        "eligibilityCriteria": "Regulile generale privind naționalitatea și originea, precum și alte criterii de eligibilitate sunt enumerate în Ghidul practic privind procedurile de contractare a acțiunilor externe ale UE (PRAG)",
         "procuringEntity": {
           "name": "National Bank of Moldova - Chişinău Branch",
           "id": "MD-IDNO-1006601001182"
@@ -89,7 +88,7 @@
             "locality": "Chişinău",
             "region": "Chişinău",
             "postalCode": "MD 2005",
-            "countryName": "Moldova"
+            "country": "MD"
           },
           "contactPoint": {
             "email": "official@bnm.md",

--- a/docs/examples/organizational-units/paraguay-planning.json
+++ b/docs/examples/organizational-units/paraguay-planning.json
@@ -39,7 +39,7 @@
             "streetAddress": "AVDA. MCAL LOPEZ ESQ. CORONEL CAZAL",
             "locality": "San Lorenzo",
             "region": "Central",
-            "countryName": "Paraguay"
+            "country": "PY"
           },
           "contactPoint": {
             "name": "LIC. LIZ RAQUEL DUARTE QUINTANA",

--- a/docs/examples/planning.json
+++ b/docs/examples/planning.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",

--- a/docs/examples/record-embedded-releases.json
+++ b/docs/examples/record-embedded-releases.json
@@ -193,7 +193,7 @@
         "parties": [
           {
             "address": {
-              "countryName": "United Kingdom",
+              "country": "GB",
               "locality": "London",
               "postalCode": "N11 1NP",
               "region": "London",
@@ -227,7 +227,7 @@
               }
             ],
             "address": {
-              "countryName": "United Kingdom",
+              "country": "GB",
               "locality": "Anytown",
               "postalCode": "AN1 1TN",
               "region": "AnyCounty",
@@ -411,9 +411,6 @@
             "name": "London Borough of Barnet"
           },
           "status": "active",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "tenderPeriod": {
             "endDate": "2011-04-01T18:00:00Z",
@@ -451,7 +448,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -617,7 +614,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -682,9 +679,6 @@
             "procurementMethodRationale": "An open competitive tender is required by EU Rules",
             "awardCriteria": "bestProposal",
             "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
             "enquiryPeriod": {
               "startDate": "2010-03-01T09:00:00Z",
@@ -740,7 +734,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -805,9 +799,6 @@
             "procurementMethodRationale": "An open competitive tender is required by EU Rules",
             "awardCriteria": "bestProposal",
             "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
             "enquiryPeriod": {
               "startDate": "2010-03-01T09:00:00Z",
@@ -891,7 +882,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -956,9 +947,6 @@
             "procurementMethodRationale": "An open competitive tender is required by EU Rules",
             "awardCriteria": "bestProposal",
             "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-            "submissionMethod": [
-              "electronicSubmission"
-            ],
             "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
             "enquiryPeriod": {
               "startDate": "2010-03-01T09:00:00Z",
@@ -1034,7 +1022,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -1067,7 +1055,7 @@
                 "locality": "Anytown",
                 "region": "AnyCounty",
                 "postalCode": "AN1 1TN",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Contracts Team",
@@ -1172,7 +1160,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -1205,7 +1193,7 @@
                 "locality": "Anytown",
                 "region": "AnyCounty",
                 "postalCode": "AN1 1TN",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Contracts Team",
@@ -1368,7 +1356,7 @@
                 "locality": "London",
                 "region": "London",
                 "postalCode": "N11 1NP",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Procurement Team",
@@ -1401,7 +1389,7 @@
                 "locality": "Anytown",
                 "region": "AnyCounty",
                 "postalCode": "AN1 1TN",
-                "countryName": "United Kingdom"
+                "country": "GB"
               },
               "contactPoint": {
                 "name": "Contracts Team",

--- a/docs/examples/record.json
+++ b/docs/examples/record.json
@@ -193,7 +193,7 @@
         "parties": [
           {
             "address": {
-              "countryName": "United Kingdom",
+              "country": "GB",
               "locality": "London",
               "postalCode": "N11 1NP",
               "region": "London",
@@ -227,7 +227,7 @@
               }
             ],
             "address": {
-              "countryName": "United Kingdom",
+              "country": "GB",
               "locality": "Anytown",
               "postalCode": "AN1 1TN",
               "region": "AnyCounty",
@@ -413,9 +413,6 @@
             "name": "London Borough of Barnet"
           },
           "status": "active",
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "tenderPeriod": {
             "endDate": "2011-04-01T18:00:00Z",

--- a/docs/examples/records/award.json
+++ b/docs/examples/records/award.json
@@ -67,7 +67,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -100,7 +100,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "E14 5HU",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Contracts Team",
@@ -259,9 +259,6 @@
               "description": "A consultation period is open for citizen input to shape the final plans.",
               "dueDate": "2015-04-15T17:00:00Z"
             }
-          ],
-          "submissionMethod": [
-            "electronicSubmission"
           ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
@@ -462,14 +459,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -659,14 +656,14 @@
                   "value": "E14 5HU"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-04-award",
                   "releaseDate": "2010-05-10T09:30:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1697,18 +1694,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/records/contract.json
+++ b/docs/examples/records/contract.json
@@ -74,7 +74,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -107,7 +107,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "E14 5HU",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Contracts Team",
@@ -266,9 +266,6 @@
               "description": "A consultation period is open for citizen input to shape the final plans.",
               "dueDate": "2015-04-15T17:00:00Z"
             }
-          ],
-          "submissionMethod": [
-            "electronicSubmission"
           ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
@@ -527,14 +524,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -724,14 +721,14 @@
                   "value": "E14 5HU"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-04-award",
                   "releaseDate": "2010-05-10T09:30:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1762,18 +1759,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/records/contractAmendment.json
+++ b/docs/examples/records/contractAmendment.json
@@ -88,7 +88,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -121,7 +121,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "E14 5HU",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Contracts Team",
@@ -280,9 +280,6 @@
               "description": "A consultation period is open for citizen input to shape the final plans.",
               "dueDate": "2015-04-15T17:00:00Z"
             }
-          ],
-          "submissionMethod": [
-            "electronicSubmission"
           ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
@@ -572,14 +569,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -769,14 +766,14 @@
                   "value": "E14 5HU"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-04-award",
                   "releaseDate": "2010-05-10T09:30:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1807,18 +1804,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/records/implementation.json
+++ b/docs/examples/records/implementation.json
@@ -81,7 +81,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -114,7 +114,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "E14 5HU",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Contracts Team",
@@ -273,9 +273,6 @@
               "description": "A consultation period is open for citizen input to shape the final plans.",
               "dueDate": "2015-04-15T17:00:00Z"
             }
-          ],
-          "submissionMethod": [
-            "electronicSubmission"
           ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
@@ -556,14 +553,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -753,14 +750,14 @@
                   "value": "E14 5HU"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-04-award",
                   "releaseDate": "2010-05-10T09:30:00Z",
                   "releaseTag": [
                     "award"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1791,18 +1788,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/records/planning.json
+++ b/docs/examples/records/planning.json
@@ -46,7 +46,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -307,14 +307,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },

--- a/docs/examples/records/tender.json
+++ b/docs/examples/records/tender.json
@@ -53,7 +53,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -205,9 +205,6 @@
               "dueDate": "2015-04-15T17:00:00Z"
             }
           ],
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
             "startDate": "2010-03-01T09:00:00Z",
@@ -334,14 +331,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1302,18 +1299,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/records/tenderUpdate.json
+++ b/docs/examples/records/tenderUpdate.json
@@ -60,7 +60,7 @@
               "locality": "London",
               "region": "London",
               "postalCode": "N11 1NP",
-              "countryName": "United Kingdom"
+              "country": "GB"
             },
             "contactPoint": {
               "name": "Procurement Team",
@@ -222,9 +222,6 @@
               "dueDate": "2015-04-15T17:00:00Z"
             }
           ],
-          "submissionMethod": [
-            "electronicSubmission"
-          ],
           "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
           "enquiryPeriod": {
             "startDate": "2010-03-01T09:00:00Z",
@@ -361,14 +358,14 @@
                   "value": "N11 1NP"
                 }
               ],
-              "countryName": [
+              "country": [
                 {
                   "releaseID": "ocds-213czf-000-00001-01-planning",
                   "releaseDate": "2009-03-15T14:45:00Z",
                   "releaseTag": [
                     "planning"
                   ],
-                  "value": "United Kingdom"
+                  "value": "GB"
                 }
               ]
             },
@@ -1402,18 +1399,6 @@
                   ],
                   "value": "2015-04-15T17:00:00Z"
                 }
-              ]
-            }
-          ],
-          "submissionMethod": [
-            {
-              "releaseID": "ocds-213czf-000-00001-02-tender",
-              "releaseDate": "2010-03-15T09:30:00Z",
-              "releaseTag": [
-                "tender"
-              ],
-              "value": [
-                "electronicSubmission"
               ]
             }
           ],

--- a/docs/examples/suspendedcontract.json
+++ b/docs/examples/suspendedcontract.json
@@ -57,7 +57,7 @@
             "region": "مرکز",
             "locality": null,
             "postalCode": null,
-            "countryName": "افغانستان",
+            "country": "AF",
             "streetAddress": null
           },
           "identifier": {
@@ -81,7 +81,7 @@
             "region": "مرکز",
             "locality": null,
             "postalCode": null,
-            "countryName": "افغانستان",
+            "country": "AF",
             "streetAddress": null
           },
           "identifier": {

--- a/docs/examples/tender.json
+++ b/docs/examples/tender.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -100,9 +100,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/tenderAmendment.json
+++ b/docs/examples/tenderAmendment.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -100,9 +100,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/tenderUpdate.json
+++ b/docs/examples/tenderUpdate.json
@@ -35,7 +35,7 @@
             "locality": "London",
             "region": "London",
             "postalCode": "N11 1NP",
-            "countryName": "United Kingdom"
+            "country": "GB"
           },
           "contactPoint": {
             "name": "Procurement Team",
@@ -100,9 +100,6 @@
         "procurementMethodRationale": "An open competitive tender is required by EU Rules",
         "awardCriteria": "bestProposal",
         "awardCriteriaDetails": "The best proposal, subject to value for money requirements, will be accepted.",
-        "submissionMethod": [
-          "electronicSubmission"
-        ],
         "submissionMethodDetails": "Submit through the online portal at http://example.com/submissions/ocds-213czf-000-00001-01/",
         "enquiryPeriod": {
           "startDate": "2010-03-01T09:00:00Z",

--- a/docs/examples/unsuccessful-tender-related-process.json
+++ b/docs/examples/unsuccessful-tender-related-process.json
@@ -63,11 +63,7 @@
         "status": "complete",
         "awardCriteria": "priceOnly",
         "awardCriteriaDetails": "Por Item",
-        "submissionMethod": [
-          "inPerson"
-        ],
         "submissionMethodDetails": "Lugar entrega ofertas: MUNICIPALIDA DE LOMA PLATA || Lugar entrega bien: Según documento del llamado || Fecha entrega bien: Según documento del llamado",
-        "eligibilityCriteria": "Restricciones: INHABILIDADES PREVISTAS EN EL ARTICULO 40 DE LA LEY 2051/03",
         "enquiriesAddress": {
           "streetAddress": "MUNICIPALIDA DE LOMA PLATA"
         },
@@ -217,7 +213,7 @@
             "url": "http://www.nissan.com.py"
           },
           "address": {
-            "countryName": "Paraguay",
+            "country": "PY",
             "locality": "ASUNCION (DISTRITO)",
             "region": "Asunción",
             "streetAddress": "Mcal López 5557 c/Rogelio Benitez"
@@ -243,7 +239,7 @@
             "url": "http://www.kurosu.com.py"
           },
           "address": {
-            "countryName": "Paraguay",
+            "country": "PY",
             "locality": "ENCARNACION",
             "region": "Itapúa",
             "streetAddress": "RUTA VI KM 6 - Bº ARROYO PORA"

--- a/docs/examples/unsuccessful-tender-tender.json
+++ b/docs/examples/unsuccessful-tender-tender.json
@@ -16,11 +16,7 @@
         "status": "unsuccessful",
         "awardCriteria": "priceOnly",
         "awardCriteriaDetails": "Por Total",
-        "submissionMethod": [
-          "inPerson"
-        ],
         "submissionMethodDetails": "Lugar entrega ofertas: MUNICIPALIDAD DE LOMA PLATA || Lugar entrega bien: Según documento del llamado || Fecha entrega bien: Según documento del llamado",
-        "eligibilityCriteria": "Restricciones: INHABILIDADES PREVISTAS EN EL ARTICULO 40 DE LA LEY 2051/03",
         "statusDetails": "Desierta",
         "enquiriesAddress": {
           "streetAddress": "MUNICIPALIDAD DE LOMA PLATA"

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -541,7 +541,11 @@
                 "type": [
                   "string",
                   "null"
-                ]
+                ],
+                "deprecated": {
+                  "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                  "deprecatedVersion": "1.2"
+                }
               }
             }
           },
@@ -1024,7 +1028,11 @@
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "deprecated": {
+                "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                "deprecatedVersion": "1.2"
+              }
             }
           },
           "deprecated": {
@@ -2395,7 +2403,11 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "deprecated": {
+                    "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                    "deprecatedVersion": "1.2"
+                  }
                 }
               },
               "deprecated": {
@@ -4816,7 +4828,11 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "deprecated": {
+                      "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                      "deprecatedVersion": "1.2"
+                    }
                   }
                 },
                 "deprecated": {
@@ -6994,7 +7010,11 @@
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "deprecated": {
+                        "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                        "deprecatedVersion": "1.2"
+                      }
                     }
                   },
                   "deprecated": {
@@ -10649,7 +10669,11 @@
                               "type": [
                                 "string",
                                 "null"
-                              ]
+                              ],
+                              "deprecated": {
+                                "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                                "deprecatedVersion": "1.2"
+                              }
                             }
                           },
                           "deprecated": {
@@ -11172,7 +11196,11 @@
                               "type": [
                                 "string",
                                 "null"
-                              ]
+                              ],
+                              "deprecated": {
+                                "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                                "deprecatedVersion": "1.2"
+                              }
                             }
                           },
                           "deprecated": {
@@ -13970,7 +13998,11 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "deprecated": {
+                    "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                    "deprecatedVersion": "1.2"
+                  }
                 }
               },
               "deprecated": {
@@ -16391,7 +16423,11 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "deprecated": {
+                      "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                      "deprecatedVersion": "1.2"
+                    }
                   }
                 },
                 "deprecated": {
@@ -18565,7 +18601,11 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "deprecated": {
+                      "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                      "deprecatedVersion": "1.2"
+                    }
                   }
                 },
                 "deprecated": {
@@ -22214,7 +22254,11 @@
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "deprecated": {
+                              "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                              "deprecatedVersion": "1.2"
+                            }
                           }
                         },
                         "deprecated": {
@@ -22737,7 +22781,11 @@
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "deprecated": {
+                              "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                              "deprecatedVersion": "1.2"
+                            }
                           }
                         },
                         "deprecated": {
@@ -24947,7 +24995,11 @@
                         "type": [
                           "string",
                           "null"
-                        ]
+                        ],
+                        "deprecated": {
+                          "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                          "deprecatedVersion": "1.2"
+                        }
                       }
                     },
                     "deprecated": {
@@ -25470,7 +25522,11 @@
                         "type": [
                           "string",
                           "null"
-                        ]
+                        ],
+                        "deprecated": {
+                          "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                          "deprecatedVersion": "1.2"
+                        }
                       }
                     },
                     "deprecated": {
@@ -27904,7 +27960,11 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "deprecated": {
+                    "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                    "deprecatedVersion": "1.2"
+                  }
                 }
               },
               "deprecated": {
@@ -28427,7 +28487,11 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "deprecated": {
+                    "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                    "deprecatedVersion": "1.2"
+                  }
                 }
               },
               "deprecated": {
@@ -29401,7 +29465,11 @@
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "deprecated": {
+                "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                "deprecatedVersion": "1.2"
+              }
             }
           },
           "deprecated": {
@@ -29975,7 +30043,11 @@
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "deprecated": {
+                "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+                "deprecatedVersion": "1.2"
+              }
             }
           }
         },
@@ -31151,7 +31223,11 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "deprecated": {
+            "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+            "deprecatedVersion": "1.2"
+          }
         }
       }
     },

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -2016,7 +2016,11 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "deprecated": {
+            "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+            "deprecatedVersion": "1.2"
+          }
         }
       }
     },

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -2172,7 +2172,11 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "deprecated": {
+            "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names.",
+            "deprecatedVersion": "1.2"
+          }
         }
       }
     },


### PR DESCRIPTION
The deprecated fields are:

* countryName: field renamed to country, and value changed to ISO code
* submissionMethod: removed
* eligibilityCriteria: removed
* packages: removed

None of the deprecated codes ('funder') were used in examples (except in the deprecated `submissionMethod` field).

This PR leaves a  `submissionMethod` in `getting_started/building_blocks.md`, but this is gone in the Primer, once I merge 1.1-dev.