### PR TITLE
Integrate content from what to do with fields that don't map blog

### DIFF
--- a/docs/guidance/map.md
+++ b/docs/guidance/map.md
@@ -114,9 +114,11 @@ map/beneficial_ownership
 
 Some data elements might not match any field or code in OCDS. To cover such cases, you can add fields and codes to OCDS using [extensions](map/extensions).
 
-**Resource:** [Localizing OCDS: Translations, Terminology & Extensions](https://www.open-contracting.org/2016/07/26/localising-ocds-translations-terminology-extensions/)
+Before using extensions, you should decide whether the additional data that you want to disclose affects how users should interpret fields in the OCDS schema. If so, consider whether you can include extra information in an existing field to alert users who only know about fields in the OCDS schema. For example, to disclose data about the disposal of state assets, in addition to using an extension, you can prefix `tender.title` with 'Disposal:'.
 
-**Resource:** [What to do when fields don't map?](https://www.open-contracting.org/2018/01/30/fields-dont-map-first/)
+You should also double-check whether the additional data that you want to disclose can be modelled using an existing field. For example, to disclose the date by which the procuring entity will respond to enquiries, rather than adding a field, you can use `tender.milestones`.
+
+**Resource:** [Localizing OCDS: Translations, Terminology & Extensions](https://www.open-contracting.org/2016/07/26/localising-ocds-translations-terminology-extensions/)
 
 **Resource** [OCDS Glossary](https://github.com/open-contracting/glossary)
 

--- a/docs/guidance/map.md
+++ b/docs/guidance/map.md
@@ -114,9 +114,16 @@ map/beneficial_ownership
 
 Some data elements might not match any field or code in OCDS. To cover such cases, you can add fields and codes to OCDS using [extensions](map/extensions).
 
-Before using extensions, you should decide whether the additional data that you want to disclose affects how users should interpret fields in the OCDS schema. If so, consider whether you can include extra information in an existing field to alert users who only know about fields in the OCDS schema. For example, to disclose data about the disposal of state assets, in addition to using an extension, you can prefix `tender.title` with 'Disposal:'.
+Before using extensions, double-check whether the data elements can be disclosed using existing fields. For example, to disclose the date by which the buyer or procuring entity will respond to enquiries, you can use the `tender.milestones` field, instead of adding a new field.
 
-You should also double-check whether the additional data that you want to disclose can be modelled using an existing field. For example, to disclose the date by which the procuring entity will respond to enquiries, rather than adding a field, you can use `tender.milestones`.
+```{seealso}
+* [Worked example: Milestones](map/organization_classifications)
+* [Worked example: Organization classification](map/organization_classifications)
+```
+
+If you do need to use an extension, consider whether the new fields will affect how users interpret existing fields. If so, you can add information to existing fields, to avoid misinterpretation – in addition to adding the new fields.
+
+For example, you have created an extension to add a new field to indicate whether a contracting process is about the disposal of a state asset (like a vehicle). If the `tender.title` field refers only to the vehicle, then users who are unaware of the new field might misinterpret the contracting process as being about its purchase. To avoid misinterpretation, you can add a "Disposal: " prefix to the `tender.title` field.
 
 **Resource:** [Localizing OCDS: Translations, Terminology & Extensions](https://www.open-contracting.org/2016/07/26/localising-ocds-translations-terminology-extensions/)
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -49,6 +49,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * Publish:
     * Merge Publication policy and Licensing pages into Publish page [#986](https://github.com/open-contracting/standard/pull/986) [#1012](https://github.com/open-contracting/standard/pull/1012).
     * Replace guidance on publication levels [#980](https://github.com/open-contracting/standard/pull/980) [#1013](https://github.com/open-contracting/standard/pull/1013) [#1045](https://github.com/open-contracting/standard/pull/1045).
+  * [#1428](https://github.com/open-contracting/standard/pull/1428) Integrate content from [what to do with fields that don't map](https://www.open-contracting.org/2018/01/30/fields-dont-map-first/).
   * Various minor improvements [#1051](https://github.com/open-contracting/standard/pull/1051) [#1080](https://github.com/open-contracting/standard/pull/1080) [#1083](https://github.com/open-contracting/standard/pull/1083) [#1085](https://github.com/open-contracting/standard/pull/1085) [#1091](https://github.com/open-contracting/standard/pull/1091) [#1130](https://github.com/open-contracting/standard/pull/1130) [#1227](https://github.com/open-contracting/standard/pull/1227) [#1299](https://github.com/open-contracting/standard/pull/1299) [#1337](https://github.com/open-contracting/standard/pull/1337) [#1384](https://github.com/open-contracting/standard/pull/1384).
 
 * [#908](https://github.com/open-contracting/standard/pull/908) Rename Validator to Data Review Tool.

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -35,6 +35,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
       * Linked standards [#1278](https://github.com/open-contracting/standard/pull/1278)
     * [#1016](https://github.com/open-contracting/standard/pull/1016) [#1140](https://github.com/open-contracting/standard/pull/1140) Add links to OCDS profiles and linked standards.
     * [#1193](https://github.com/open-contracting/standard/pull/1193) Removed language distinguishing "core", "community", and "local" extensions.
+    * [#1428](https://github.com/open-contracting/standard/pull/1428) Integrate content from [what to do with fields that don't map](https://www.open-contracting.org/2018/01/30/fields-dont-map-first/).
   * Build:
     * Add pages:
       * "Easy" releases [#951](https://github.com/open-contracting/standard/pull/951)
@@ -49,7 +50,6 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * Publish:
     * Merge Publication policy and Licensing pages into Publish page [#986](https://github.com/open-contracting/standard/pull/986) [#1012](https://github.com/open-contracting/standard/pull/1012).
     * Replace guidance on publication levels [#980](https://github.com/open-contracting/standard/pull/980) [#1013](https://github.com/open-contracting/standard/pull/1013) [#1045](https://github.com/open-contracting/standard/pull/1045).
-  * [#1428](https://github.com/open-contracting/standard/pull/1428) Integrate content from [what to do with fields that don't map](https://www.open-contracting.org/2018/01/30/fields-dont-map-first/).
   * Various minor improvements [#1051](https://github.com/open-contracting/standard/pull/1051) [#1080](https://github.com/open-contracting/standard/pull/1080) [#1083](https://github.com/open-contracting/standard/pull/1083) [#1085](https://github.com/open-contracting/standard/pull/1085) [#1091](https://github.com/open-contracting/standard/pull/1091) [#1130](https://github.com/open-contracting/standard/pull/1130) [#1227](https://github.com/open-contracting/standard/pull/1227) [#1299](https://github.com/open-contracting/standard/pull/1299) [#1337](https://github.com/open-contracting/standard/pull/1337) [#1384](https://github.com/open-contracting/standard/pull/1384).
 
 * [#908](https://github.com/open-contracting/standard/pull/908) Rename Validator to Data Review Tool.


### PR DESCRIPTION
From https://github.com/open-contracting/extension-explorer/issues/47#issuecomment-935276292

Integrate the content from https://www.open-contracting.org/2018/01/30/fields-dont-map-first/.

Presumably, we also want to remove the link to the blog, so I've done that too.