### PR TITLE
docs: remove planning reference from versioned release example

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -237,7 +237,6 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * [#1067](https://github.com/open-contracting/standard/pull/1067) `Publisher.name`, to indicate that it is the organization or department responsible for publishing the OCDS version of the data.
 
 * [#1450](https://github.com/open-contracting/standard/pull/1450) Replace a repeated example in schema/merging/ with a link to guidance/build/merging/.
-* [#1450](https://github.com/open-contracting/standard/pull/1472) Remove planning reference from the versioned release example.
 
 ### Documentation
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -237,6 +237,7 @@ Per the [normative and non-normative content and changes policy](https://docs.go
   * [#1067](https://github.com/open-contracting/standard/pull/1067) `Publisher.name`, to indicate that it is the organization or department responsible for publishing the OCDS version of the data.
 
 * [#1450](https://github.com/open-contracting/standard/pull/1450) Replace a repeated example in schema/merging/ with a link to guidance/build/merging/.
+* [#1450](https://github.com/open-contracting/standard/pull/1472) Remove planning reference from the versioned release example.
 
 ### Documentation
 

--- a/docs/schema/records_reference.md
+++ b/docs/schema/records_reference.md
@@ -109,7 +109,7 @@ This versioned information is relevant to many use cases relating to contract mo
 
 If the versioned release is not provided, third parties can generate it by processing the record's releases according to the [merging](merging) reference.
 
-The following example displays a single field's [versioned values](merging.md#versioned-values). This shows that the amount changed between the planning stage and the tender stage, while the currency did not.
+The following example displays a single field's [versioned values](merging.md#versioned-values). This shows that the amount changed between the tender stage and a tender amendment while the currency did not.
 
 ```{jsoninclude} ../examples/merging/versioned.json
 :jsonpointer: /records/0/versionedRelease/tender/value

--- a/docs/schema/records_reference.md
+++ b/docs/schema/records_reference.md
@@ -109,7 +109,7 @@ This versioned information is relevant to many use cases relating to contract mo
 
 If the versioned release is not provided, third parties can generate it by processing the record's releases according to the [merging](merging) reference.
 
-The following example displays a single field's [versioned values](merging.md#versioned-values). This shows that the amount changed between the tender stage and a tender amendment while the currency did not.
+The following example displays a single field's [versioned values](merging.md#versioned-values). This shows that the amount changed between the tender stage and a tender amendment, while the currency did not.
 
 ```{jsoninclude} ../examples/merging/versioned.json
 :jsonpointer: /records/0/versionedRelease/tender/value


### PR DESCRIPTION
closes #1362 