### PR TITLE
1292 alternative representations of documents

### DIFF
--- a/docs/examples/release_schema_reference/release_package.json
+++ b/docs/examples/release_schema_reference/release_package.json
@@ -216,7 +216,7 @@
           {
             "id": "0001",
             "documentType": "tenderNotice",
-            "title": "Enquiry Responses",
+            "title": "Tender notice",
             "description": "Tender Notice",
             "url": "http://example.com/tenderNotice/ocds-213czf-000-00001-01.html",
             "datePublished": "2010-03-20T11:30:15Z",

--- a/docs/guidance/map.md
+++ b/docs/guidance/map.md
@@ -141,6 +141,10 @@ For example, you have created an extension to add a new field to indicate whethe
 map/extensions
 ```
 
+## Link OCDS with alternative representations
+
+The data contained in an OCDS release is often available via alternative representations, such as the HTML or PDF version of a notice. You ought to link to alternative representations from your OCDS data so that users can follow up on contracting processes that they are interested in, for example to submit a bid, or to subscribe to notifications. For more information on linking to alternative representations, refer to the [`Document` reference](../schema/reference.md#document).
+
 ## Link OCDS with other standards
 
 Not all information that is related to a contracting (or planning) process belongs in OCDS. For example, a company's annual filings and incorporation status are typically managed in a company registry, outside the lifecycle of a contracting process.

--- a/docs/guidance/map.md
+++ b/docs/guidance/map.md
@@ -143,7 +143,7 @@ map/extensions
 
 ## Link OCDS with alternative representations
 
-The data contained in an OCDS release is often available via alternative representations, such as the HTML or PDF version of a notice. You ought to link to alternative representations from your OCDS data so that users can follow up on contracting processes that they are interested in, for example to submit a bid, or to subscribe to notifications. For more information on linking to alternative representations, refer to the [`Document` reference](../schema/reference.md#document).
+The data contained in an OCDS release is often available in other formats, such as the HTML or PDF version of a notice. You ought to link to these alternative representations from your OCDS data, so that users can follow up on contracting processes that they are interested in: for example, to submit a bid, or to subscribe to notifications. For more information on linking to alternative representations, refer to the [`Document` reference](../schema/reference.md#document).
 
 ## Link OCDS with other standards
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -311,7 +311,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
 * [#1643](https://github.com/open-contracting/standard/pull/1643) Update identifier section in release reference.
 * [#1655](https://github.com/open-contracting/standard/pull/1655) Rewrite identifiers reference and examples for clarity.
 * [#1659](https://github.com/open-contracting/standard/pull/1659) Add `Record` definition schema table to record reference.
-* [#1664](https://github.com/open-contracting/standard/pull/1664) Recommend linking to alternative representations using `documents`, fix incoherent `tender.documents` example.
+* [#1664](https://github.com/open-contracting/standard/pull/1664) Recommend linking to alternative representations using `documents`.
 
 ## [1.1.5] - 2020-08-20
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -311,6 +311,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
 * [#1643](https://github.com/open-contracting/standard/pull/1643) Update identifier section in release reference.
 * [#1655](https://github.com/open-contracting/standard/pull/1655) Rewrite identifiers reference and examples for clarity.
 * [#1659](https://github.com/open-contracting/standard/pull/1659) Add `Record` definition schema table to record reference.
+* [#1664](https://github.com/open-contracting/standard/pull/1664) Recommend linking to alternative representations using `documents`, fix incoherent `tender.documents` example.
 
 ## [1.1.5] - 2020-08-20
 

--- a/docs/schema/reference.md
+++ b/docs/schema/reference.md
@@ -477,6 +477,8 @@ OCDS allows summarizing information in the document's `description` field. Provi
 
 If a document contains multiple languages, use the `languages` field to list the languages used in the document. If there are multiple versions of a document, each in a different language, add a separate `Document` object for each version of the document.
 
+If an alternative representation of the data in an OCDS release exists, a link should be provided in the relevant `.documents` array. For example, if the data in an OCDS award release is also available as an HTML page, a link to the HTML page should be provided in `awards.documents`. Links to alternative representations of an entire contracting process should be provided in `tender.documents`.
+
 ````{admonition} Example
 :class: hint
 


### PR DESCRIPTION
* Closes #1292 
* Fixes incoherent `tender.documents` example