### PR TITLE
release-schema.json: move tender.submissionTerms to definitions.Submi…

### DIFF
--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -37035,6 +37035,29 @@
           "versionId": true
         }
       }
+    },
+    "SubmissionTerms": {
+      "title": "Submission terms",
+      "description": "Information about how, when and where tenderers need to submit their bids.",
+      "type": "object",
+      "properties": {
+        "electronicSubmissionPolicy": {
+          "title": "Electronic submission policy",
+          "description": "Whether tenderers are required, allowed or not allowed to submit bids electronically.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "codelist": "permission.csv",
+          "openCodelist": false,
+          "enum": [
+            "required",
+            "allowed",
+            "notAllowed",
+            null
+          ]
+        }
+      }
     }
   }
 }

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -401,25 +401,7 @@
         "submissionTerms": {
           "title": "Submission terms",
           "description": "Information about how, when and where tenderers need to submit their bids.",
-          "type": "object",
-          "properties": {
-            "electronicSubmissionPolicy": {
-              "title": "Electronic submission policy",
-              "description": "Whether tenderers are required, allowed or not allowed to submit bids electronically.",
-              "type": [
-                "string",
-                "null"
-              ],
-              "codelist": "permission.csv",
-              "openCodelist": false,
-              "enum": [
-                "required",
-                "allowed",
-                "notAllowed",
-                null
-              ]
-            }
-          }
+          "$ref": "#/definitions/SubmissionTerms"
         },
         "datePublished": {
           "description": "The date on which the tender was published.",
@@ -2765,6 +2747,29 @@
             "null"
           ],
           "versionId": true
+        }
+      }
+    },
+    "SubmissionTerms": {
+      "title": "Submission terms",
+      "description": "Information about how, when and where tenderers need to submit their bids.",
+      "type": "object",
+      "properties": {
+        "electronicSubmissionPolicy": {
+          "title": "Electronic submission policy",
+          "description": "Whether tenderers are required, allowed or not allowed to submit bids electronically.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "codelist": "permission.csv",
+          "openCodelist": false,
+          "enum": [
+            "required",
+            "allowed",
+            "notAllowed",
+            null
+          ]
         }
       }
     }

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -462,44 +462,7 @@
           "$ref": "#/definitions/StringNullVersioned"
         },
         "submissionTerms": {
-          "type": "object",
-          "properties": {
-            "electronicSubmissionPolicy": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "releaseDate": {
-                    "format": "date-time",
-                    "type": "string"
-                  },
-                  "releaseID": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "codelist": "permission.csv",
-                    "openCodelist": false,
-                    "enum": [
-                      "required",
-                      "allowed",
-                      "notAllowed",
-                      null
-                    ]
-                  },
-                  "releaseTag": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "$ref": "#/definitions/SubmissionTerms"
         },
         "datePublished": {
           "$ref": "#/definitions/StringNullDateTimeVersioned"
@@ -3116,6 +3079,46 @@
                   "null"
                 ],
                 "versionId": true
+              },
+              "releaseTag": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "SubmissionTerms": {
+      "type": "object",
+      "properties": {
+        "electronicSubmissionPolicy": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "releaseDate": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "releaseID": {
+                "type": "string"
+              },
+              "value": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "codelist": "permission.csv",
+                "openCodelist": false,
+                "enum": [
+                  "required",
+                  "allowed",
+                  "notAllowed",
+                  null
+                ]
               },
               "releaseTag": {
                 "type": "array",


### PR DESCRIPTION
…ssionTerms

Moved `Tender.submissionTerms` to `definitions.SubmissionTerms` to allow it to be referenced in the Lots extension.