### PR TITLE
release-schema.json: deprecate Contract.relatedProcesses and 'parent'…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: pip

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -5,8 +5,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install standard eslint-plugin-import@2.26.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,11 @@ env:
   BASEDIR: https://raw.githubusercontent.com/open-contracting/standard-maintenance-scripts/main
 jobs:
   build:
-    if: github.event_name == 'pull_request' || startsWith(github.event.ref, 'refs/tags/') || startsWith(github.event.ref, 'refs/heads/1.1') || startsWith(github.event.ref, 'refs/heads/1.2')
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: pip

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -5,7 +5,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install shellcheck
         run: |
           sudo apt update

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,8 +5,8 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: pip install codespell

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 /docs/_static/patched
 /src
 *.pyc
-.python-version

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -64,7 +64,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   myst-parser
     #   sphinx
@@ -103,7 +103,7 @@ packaging==21.3
     #   build
     #   pytest
     #   sphinx
-pip-tools==6.13.0
+pip-tools==7.3.0
     # via -r common-requirements.in
 platformdirs==3.9.1
     # via requests-cache
@@ -168,6 +168,7 @@ sphinxcontrib-serializinghtml==1.1.5
 tomli==2.0.1
     # via
     #   build
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
 tornado==6.3.3
@@ -186,7 +187,7 @@ uc-micro-py==1.0.1
     # via linkify-it-py
 url-normalize==1.4.3
     # via requests-cache
-urllib3[socks]==1.26.5
+urllib3[socks]==1.26.18
     # via
     #   elastic-transport
     #   requests

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -165,6 +165,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * Deprecate "parent-to-child" codes: 'subContract', 'replacementProcess' and 'renewalProcess'
   * Add child-to-parent code: 'parent' (the reverse of 'subContract')
   * Update descriptions: 'prior', 'framework', 'unsuccessfulProcess'
+* [#1670](https://github.com/open-contracting/standard/pull/1670) `relatedProcess.csv` deprecate 'parent'.
 
 ### Schema
 
@@ -215,6 +216,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * [#1380](https://github.com/open-contracting/standard/pull/1380) `Document.language` in favor of the new `Document.languages` field, to support documents in which multiple languages are used.
   * [#1509](https://github.com/open-contracting/standard/pull/1509) `tender.status`, `Award.status`, `Contract.status`, because the same information can be provided by filling in the relevant date fields.
   * [#1662](https://github.com/open-contracting/standard/pull/1662) `Transaction.source`, because its value would be potentially identical across every transaction.
+  * [#1670](https://github.com/open-contracting/standard/pull/1670) `Contract.relatedProcesses`, because parent to child relationships are no longer supported and subcontracts are recorded as part of main contract in original contracting process.
 
 * Update and clarify field descriptions:
   * [#1113](https://github.com/open-contracting/standard/pull/1113) `ocid`, to recommend a hyphen after the ocid prefix.

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -161,11 +161,10 @@ Per the [normative and non-normative content and changes policy](../governance/n
 * [#1209](https://github.com/open-contracting/standard/pull/1209) Replace "electronic goods" with "digital goods" in the description of 'goods' from the `procurementCategory` codelist, to align with the description in the World Trade Organization's Agreement on Government Procurement, and to avoid confusion between electronic goods like computers and digital goods like software.
 * [#1530](https://github.com/open-contracting/standard/pull/1530) Use consistent wording for "goods, services and/or works" in the `classificationScheme`, `extendedProcurementCategory`, `partyRole` and `procurementCategory` codelists.
 * [#1550](https://github.com/open-contracting/standard/pull/1550) Align and improve code descriptions in `extendedProcurementCategory` and `procurementCategory`.
-* [#1645](https://github.com/open-contracting/standard/pull/1645) `relatedProcess.csv`:
-  * Deprecate "parent-to-child" codes: 'subContract', 'replacementProcess' and 'renewalProcess'
-  * Add child-to-parent code: 'parent' (the reverse of 'subContract')
-  * Update descriptions: 'prior', 'framework', 'unsuccessfulProcess'
-* [#1670](https://github.com/open-contracting/standard/pull/1670) `relatedProcess.csv` deprecate 'parent'.
+* `relatedProcess.csv`:
+  * [#1645](https://github.com/open-contracting/standard/pull/1645) Deprecate "parent-to-child" codes: 'subContract', 'replacementProcess' and 'renewalProcess'
+  * [#1670](https://github.com/open-contracting/standard/pull/1670) Deprecate 'parent' code, because a subcontract needs to be described within its main contract, not within a separate contracting process
+  * [#1645](https://github.com/open-contracting/standard/pull/1645) Update descriptions: 'prior', 'framework', 'unsuccessfulProcess'
 
 ### Schema
 
@@ -216,7 +215,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * [#1380](https://github.com/open-contracting/standard/pull/1380) `Document.language` in favor of the new `Document.languages` field, to support documents in which multiple languages are used.
   * [#1509](https://github.com/open-contracting/standard/pull/1509) `tender.status`, `Award.status`, `Contract.status`, because the same information can be provided by filling in the relevant date fields.
   * [#1662](https://github.com/open-contracting/standard/pull/1662) `Transaction.source`, because its value would be potentially identical across every transaction.
-  * [#1670](https://github.com/open-contracting/standard/pull/1670) `Contract.relatedProcesses`, because parent to child relationships are no longer supported and subcontracts are recorded as part of main contract in original contracting process.
+  * [#1670](https://github.com/open-contracting/standard/pull/1670) `Contract.relatedProcesses`, because all relevant codes from the relatedProcess codelist are deprecated.
 
 * Update and clarify field descriptions:
   * [#1113](https://github.com/open-contracting/standard/pull/1113) `ocid`, to recommend a hyphen after the ocid prefix.

--- a/include/common.mk
+++ b/include/common.mk
@@ -1,15 +1,15 @@
 # See https://github.com/datamade/data-making-guidelines
 
-# See http://clarkgrubb.com/makefile-style-guide#phony-target-arg
+# See https://clarkgrubb.com/makefile-style-guide#phony-target-arg
 FORCE:
 
-# http://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
+# https://blog.jgc.org/2007/06/escaping-comma-and-space-in-gnu-make.html
 COMMA := ,
 SPACE :=
 SPACE +=
 COMMA_SEPARATED_TRANSLATIONS=$(subst $(SPACE),$(COMMA),$(TRANSLATIONS:.%=%))
 
-# See http://clarkgrubb.com/makefile-style-guide#phony-targets
+# See https://clarkgrubb.com/makefile-style-guide#phony-targets
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)
@@ -45,7 +45,7 @@ extract_schema: $(POT_DIR)
 
 # The codelist CSV files and JSON Schema files must be present for the `csv-table-no-translate` and `jsonschema`
 # directives to succeed, but the contents of the files have no effect on the generated .pot files.
-# See http://www.sphinx-doc.org/en/stable/builders.html#sphinx.builders.gettext.MessageCatalogBuilder
+# See https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.gettext.MessageCatalogBuilder
 .PHONY: extract_markdown
 extract_markdown: current_lang.en
 	sphinx-build -nW --keep-going -q -b gettext $(DOCS_DIR) $(POT_DIR)
@@ -110,7 +110,7 @@ clean_current_lang:
 ### Build
 
 # Build the source documentation.
-# See http://www.sphinx-doc.org/en/stable/builders.html#sphinx.builders.html.DirectoryHTMLBuilder
+# See https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.html.DirectoryHTMLBuilder
 .PHONY: build_source
 build_source: current_lang.en
 	sphinx-build -nW --keep-going -q -b dirhtml $(DOCS_DIR) $(BUILD_DIR)/en

--- a/include/prologue.mk
+++ b/include/prologue.mk
@@ -1,4 +1,4 @@
-# See http://clarkgrubb.com/makefile-style-guide#prologue
+# See https://clarkgrubb.com/makefile-style-guide#prologue
 MAKEFLAGS += --warn-undefined-variables
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c

--- a/schema/codelists/relatedProcess.csv
+++ b/schema/codelists/relatedProcess.csv
@@ -1,9 +1,9 @@
 Code,Title,Description,Deprecated,Deprecation note
 framework,Framework agreement procedure first stage,The contracting process is the second stage of a framework agreement procedure. The related process is the contracting process that established the framework agreement.,,
 planning,Planning process,The related process is the planning process that planned the contracting process.,,
-parent,Parent contract (for sub-contracts),The contracting process aims to conclude one or more sub-contracts. The related process is the contracting process that concluded the main contract.,1.2,Deprecated because OCDS 1.2 models subcontracts as part of the main contract in the original contracting process.
+parent,Parent contract (for sub-contracts),The contracting process aims to conclude one or more sub-contracts. The related process is the contracting process that concluded the main contract.,1.2,"Deprecated because OCDS 1.2 describes a subcontract within its main contract, not within a separate contracting process."
 prior,Successful process,"The contracting process aims to extend, renew, repeat or replace one or more contracts from the related contracting process.",,
 unsuccessfulProcess,Unsuccessful process,The contracting process is another attempt to conclude one or more contracts. The related process is the contracting process that attempted and failed to conclude the contracts previously.,,
-subContract,Sub-contract,The related process might result in a sub-contract of this contract.,1.2,Deprecated because OCDS 1.2 models subcontracts as part of the main contract in the original contracting process.
+subContract,Sub-contract,The related process might result in a sub-contract of this contract.,1.2,"Deprecated because OCDS 1.2 describes a subcontract within its main contract, not within a separate contracting process."
 replacementProcess,Replacement process,The related process might result in the replacement of this contract.,1.2,"Deprecated in favor of 'prior', because  OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
-renewalProcess,Renewal process,The related process might result in the renewal of this contract.,1.2,"Deprecated in favor of 'prior, because OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
+renewalProcess,Renewal process,The related process might result in the renewal of this contract.,1.2,"Deprecated in favor of 'prior', because OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."

--- a/schema/codelists/relatedProcess.csv
+++ b/schema/codelists/relatedProcess.csv
@@ -1,9 +1,9 @@
 Code,Title,Description,Deprecated,Deprecation note
 framework,Framework agreement procedure first stage,The contracting process is the second stage of a framework agreement procedure. The related process is the contracting process that established the framework agreement.,,
 planning,Planning process,The related process is the planning process that planned the contracting process.,,
-parent,Parent contract (for sub-contracts),The contracting process aims to conclude one or more sub-contracts. The related process is the contracting process that concluded the main contract.,,
+parent,Parent contract (for sub-contracts),The contracting process aims to conclude one or more sub-contracts. The related process is the contracting process that concluded the main contract.,1.2,Deprecated because OCDS 1.2 models subcontracts as part of the main contract in the original contracting process.
 prior,Successful process,"The contracting process aims to extend, renew, repeat or replace one or more contracts from the related contracting process.",,
 unsuccessfulProcess,Unsuccessful process,The contracting process is another attempt to conclude one or more contracts. The related process is the contracting process that attempted and failed to conclude the contracts previously.,,
-subContract,Sub-contract,The related process might result in a sub-contract of this contract.,1.2,"Deprecated in favor of 'parent', because OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
-replacementProcess,Replacement process,The related process might result in the replacement of this contract.,1.2,"Deprecated in favor of 'successfulProcess', because  OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
-renewalProcess,Renewal process,The related process might result in the renewal of this contract.,1.2,"Deprecated in favor of 'successfulProcess', because OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
+subContract,Sub-contract,The related process might result in a sub-contract of this contract.,1.2,Deprecated because OCDS 1.2 models subcontracts as part of the main contract in the original contracting process.
+replacementProcess,Replacement process,The related process might result in the replacement of this contract.,1.2,"Deprecated in favor of 'prior', because  OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."
+renewalProcess,Renewal process,The related process might result in the renewal of this contract.,1.2,"Deprecated in favor of 'prior, because OCDS 1.2 follows a ""child refers to parent"" approach to linking related processes."

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -2335,7 +2335,7 @@
             null
           ],
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },
@@ -6241,7 +6241,7 @@
             "codelist": "awardStatus.csv",
             "openCodelist": false,
             "deprecated": {
-              "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+              "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
               "deprecatedVersion": "1.2"
             }
           },
@@ -8781,7 +8781,7 @@
             "codelist": "contractStatus.csv",
             "openCodelist": false,
             "deprecated": {
-              "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+              "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
               "deprecatedVersion": "1.2"
             }
           },
@@ -15272,7 +15272,7 @@
             null
           ],
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },
@@ -19174,7 +19174,7 @@
           "codelist": "awardStatus.csv",
           "openCodelist": false,
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },
@@ -21708,7 +21708,7 @@
           "codelist": "contractStatus.csv",
           "openCodelist": false,
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -13146,7 +13146,11 @@
             },
             "description": "The details of related processes: for example, if this process is followed by one or more contracting processes, represented under a separate ocid. This is commonly used to refer to subcontracts and to renewal or replacement processes for this contract.",
             "title": "Related processes",
-            "type": "array"
+            "type": "array",
+            "deprecated": {
+              "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+              "deprecatedVersion": "1.2"
+            }
           },
           "milestones": {
             "title": "Contract milestones",
@@ -26069,7 +26073,11 @@
           },
           "description": "The details of related processes: for example, if this process is followed by one or more contracting processes, represented under a separate ocid. This is commonly used to refer to subcontracts and to renewal or replacement processes for this contract.",
           "title": "Related processes",
-          "type": "array"
+          "type": "array",
+          "deprecated": {
+            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "deprecatedVersion": "1.2"
+          }
         },
         "milestones": {
           "title": "Contract milestones",

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -13148,7 +13148,7 @@
             "title": "Related processes",
             "type": "array",
             "deprecated": {
-              "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+              "description": "This field is deprecated, because all relevant codes from the relatedProcess codelist are deprecated.",
               "deprecatedVersion": "1.2"
             }
           },
@@ -26075,7 +26075,7 @@
           "title": "Related processes",
           "type": "array",
           "deprecated": {
-            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "description": "This field is deprecated, because all relevant codes from the relatedProcess codelist are deprecated.",
             "deprecatedVersion": "1.2"
           }
         },

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -808,7 +808,7 @@
           "title": "Related processes",
           "type": "array",
           "deprecated": {
-            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "description": "This field is deprecated, because all relevant codes from the relatedProcess codelist are deprecated.",
             "deprecatedVersion": "1.2"
           }
         },

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -806,7 +806,11 @@
           },
           "description": "The details of related processes: for example, if this process is followed by one or more contracting processes, represented under a separate ocid. This is commonly used to refer to subcontracts and to renewal or replacement processes for this contract.",
           "title": "Related processes",
-          "type": "array"
+          "type": "array",
+          "deprecated": {
+            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "deprecatedVersion": "1.2"
+          }
         },
         "milestones": {
           "title": "Contract milestones",

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -244,7 +244,7 @@
             null
           ],
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },
@@ -567,7 +567,7 @@
           "codelist": "awardStatus.csv",
           "openCodelist": false,
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },
@@ -734,7 +734,7 @@
           "codelist": "contractStatus.csv",
           "openCodelist": false,
           "deprecated": {
-            "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+            "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
             "deprecatedVersion": "1.2"
           }
         },

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -875,7 +875,7 @@
           },
           "type": "array",
           "deprecated": {
-            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "description": "This field is deprecated, because all relevant codes from the relatedProcess codelist are deprecated.",
             "deprecatedVersion": "1.2"
           }
         },

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -238,7 +238,7 @@
                   null
                 ],
                 "deprecated": {
-                  "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+                  "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
                   "deprecatedVersion": "1.2"
                 }
               },
@@ -645,7 +645,7 @@
                 "codelist": "awardStatus.csv",
                 "openCodelist": false,
                 "deprecated": {
-                  "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+                  "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
                   "deprecatedVersion": "1.2"
                 }
               },
@@ -819,7 +819,7 @@
                 "codelist": "contractStatus.csv",
                 "openCodelist": false,
                 "deprecated": {
-                  "description": "Deprecated because the same information can be provided by filling in the relevant date fields.",
+                  "description": "This field is deprecated, because the same information can be provided by filling in the relevant date fields.",
                   "deprecatedVersion": "1.2"
                 }
               },

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -873,7 +873,11 @@
           "items": {
             "$ref": "#/definitions/RelatedProcess"
           },
-          "type": "array"
+          "type": "array",
+          "deprecated": {
+            "description": "This field is deprecated in favor of `Tender.relatedProcesses`, `Award.relatedProcesses` and the Subcontracting extension, to reflect the updated modelling that removes the 'parent refers to child' approach to linking related processes, and records subcontracts as part of the main contract in the original contracting process.",
+            "deprecatedVersion": "1.2"
+          }
         },
         "milestones": {
           "type": "array",

--- a/script/update
+++ b/script/update
@@ -4,7 +4,7 @@ set -euo pipefail
 function main {
     mkdir -p script include tests
 
-    for f in Makefile common-requirements.in common-requirements.txt .github/workflows/lint.yml .github/workflows/shell.yml docs/_static/favicon-16x16.ico include/common.mk include/prologue.mk include/header.html script/diff script/update tests/conftest.py tests/test_common.py; do
+    for f in Makefile common-requirements.in common-requirements.txt .github/dependabot.yml .github/workflows/lint.yml .github/workflows/shell.yml docs/_static/favicon-16x16.ico include/common.mk include/prologue.mk include/header.html script/diff script/update tests/conftest.py tests/test_common.py; do
         curl -sS -o $f https://raw.githubusercontent.com/open-contracting/standard_profile_template/latest/$f
     done
 


### PR DESCRIPTION
… in relatedProcess.csv

closes #1650 

also fixed a mistake left over from https://github.com/open-contracting/standard/pull/1645 that left in references to the code 'successfulProcess' that was changed back to 'prior'