### PR TITLE
conformance_and_extensions.md: add normative guidance about extension…

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -6,10 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install shellcheck
-        run: |
+      - run: |
           sudo apt update
-          sudo apt install shellcheck
-      - run: sudo snap install shfmt
+          sudo apt install shellcheck shfmt
       - run: shellcheck $(shfmt -f .)
       - run: shfmt -d -i 4 -sr $(shfmt -f .)

--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -133,7 +133,7 @@ requests-cache==1.1.0
     # via ocdsextensionregistry
 selenium==4.11.2
     # via -r common-requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   livereload
     #   url-normalize

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ html_theme_options = {
     'license_url': f'{repository_url}/blob/HEAD/LICENSE',
     'repository_url': repository_url,
 }
+html_short_title = f'{html_theme_options["short_project"]} v{release}'
 
 # List the extension identifiers and versions that should be part of this specification. The extensions must be in
 # the extension registry: https://github.com/open-contracting/extension_registry/blob/main/extension_versions.csv

--- a/docs/guidance/index.md
+++ b/docs/guidance/index.md
@@ -6,7 +6,7 @@ The four phases of implementation described in this guide have helped implemente
 
 Read the guidance to understand the main steps to implement OCDS and to find supporting resources. Detailed guidance on specific topics and tasks is provided in sub-pages.
 
-Use the [OCDS Implementation Checklist](https://www.open-contracting.org/resources/ocds-implementation-checklist) to keep track of your progress.
+Use the [OCDS Implementation Checklist](https://www.open-contracting.org/resources/ocds-implementation-checklist/) to keep track of your progress.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/guidance/map/extensions.md
+++ b/docs/guidance/map/extensions.md
@@ -23,11 +23,7 @@ This version of OCDS uses these specific versions of the following extensions:
 
 ## Developing new extensions
 
-If you have additional fields which cannot be mapped to the OCDS schema or an existing extension, you ought to include these in your OCDS data and create a new extension to document their structure and meaning.
-
-### Extension template
-
-You can find the [extension template](https://github.com/open-contracting/standard_extension_template) on GitHub. It contains guidance on creating an extension.
+If you have additional fields which cannot be mapped to the OCDS schema or an existing extension, you ought to include these in your OCDS data and create a new extension to document their structure and meaning. Use the [extension template](https://github.com/open-contracting/standard_extension_template) to create an extension.
 
 ## Profiles
 

--- a/docs/guidance/map/extensions.md
+++ b/docs/guidance/map/extensions.md
@@ -33,9 +33,13 @@ Groups of extensions can be combined into **profiles**. OCDS provides a common c
 
 [OCDS for Public-Private Partnerships](https://standard.open-contracting.org/profiles/ppp/latest/en/) (PPPs) describes how to use OCDS to publish information about PPPs. The profile extends OCDS to offer a data format that follows the World Bank Group's [Framework for Disclosure in Public-Private Partnership Projects](https://www.worldbank.org/en/topic/publicprivatepartnerships/brief/ppp-tools#T1).
 
-### OCDS for the European Union
+### OCDS for eForms
 
-[OCDS for the European Union](https://standard.open-contracting.org/profiles/eu/latest/en/) describes how to express, in OCDS, the information in Tenders Electronic Daily (TED) notices as obliged by law within the EU.
+[OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/) describes how to express, in OCDS, European public procurement information collected through [eForms](https://single-market-economy.ec.europa.eu/single-market/public-procurement/digital-procurement/eforms_en).
+
+```{note}
+eForms is established by the [Commission Implementing Regulation (EU) 2019/1780](https://eur-lex.europa.eu/eli/reg_impl/2019/1780/oj), which repeals the [Commission Implementing Regulation (EU) 2015/1986](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32015R1986). [OCDS for the European Union](https://standard.open-contracting.org/profiles/eu/latest/en/) is relevant to the repealed regulation.
+```
 
 ### OCDS for the Agreement on Government Procurement
 

--- a/docs/locale/es/LC_MESSAGES/guidance/index.po
+++ b/docs/locale/es/LC_MESSAGES/guidance/index.po
@@ -55,11 +55,11 @@ msgstr ""
 #: ../../docs/guidance/index.md:9
 msgid ""
 "Use the [OCDS Implementation Checklist](https://www.open-"
-"contracting.org/resources/ocds-implementation-checklist) to keep track of "
+"contracting.org/resources/ocds-implementation-checklist/) to keep track of "
 "your progress."
 msgstr ""
 "Utilice la [Lista de Verificación de Implementación](https://www.open-"
-"contracting.org/resources/ocds-implementation-checklist) para hacer un "
+"contracting.org/resources/ocds-implementation-checklist/) para hacer un "
 "seguimiento de su progreso."
 
 #: ../../docs/guidance/index.md:20

--- a/docs/locale/fr/LC_MESSAGES/guidance/index.po
+++ b/docs/locale/fr/LC_MESSAGES/guidance/index.po
@@ -46,7 +46,7 @@ msgstr ""
 #: ../../docs/guidance/index.md:9
 msgid ""
 "Use the [OCDS Implementation Checklist](https://www.open-"
-"contracting.org/resources/ocds-implementation-checklist) to keep track of "
+"contracting.org/resources/ocds-implementation-checklist/) to keep track of "
 "your progress."
 msgstr ""
 

--- a/docs/schema/conformance_and_extensions.md
+++ b/docs/schema/conformance_and_extensions.md
@@ -19,14 +19,8 @@ Whenever using terms from outside the OCDS standard, we encourage the publisher 
 
 ## Extensions
 
-If you have additional fields which cannot be mapped to the OCDS schema or an existing extension, you should include these in your OCDS data and [create a new extension](../guidance/map/extensions) to document their structure and meaning.
+If you have additional fields which cannot be mapped to the OCDS schema or an existing extension, you should include these in your OCDS data and [create a new extension](../guidance/map/extensions) to document their structure and meaning. Extensions ought to be documented and shared so that other publishers and users can draw upon them, and so that extensions can be considered for inclusion in a future version of the standard. The [Extension Explorer](../guidance/map/extensions) publishes details of known extensions.
 
-Extensions to the standard can add new objects and fields to accommodate specific local requirements. An extension must not be created if it is possible to use existing terms from the standard.
-
-Extensions ought to be documented and shared so that other publishers and users can draw upon them, and so that extensions can be considered for inclusion in a future version of the standard.
-
-The [Extension Explorer](../guidance/map/extensions) publishes details of known extensions.
+Extensions to the standard can add new objects and fields to accommodate specific local requirements. An extension must not be created if it is possible to use existing terms from the standard. It must be possible to access an extension's schema and codelist files by replacing `extension.json` in the extension's URL with a file's path, e.g. `release-schema.json` or `codelists/codelist.csv`. For more information, refer to the Extension Explorer's [guidance on documenting extensions](https://extensions.open-contracting.org/en/publishers/#document).
 
 The schema for the standard by default allows for new fields, and does not fail validation of a file which contains unknown fields.
-
-It must be possible to access an extension's schema and codelist files by replacing `extension.json` in the extension's URL with a file's path, e.g. `release-schema.json` or `codelists/codelist.csv`. For more information, refer to the Extension Explorer's [guidance on documenting extensions](https://extensions.open-contracting.org/en/publishers/#document).

--- a/docs/schema/conformance_and_extensions.md
+++ b/docs/schema/conformance_and_extensions.md
@@ -27,4 +27,6 @@ Extensions ought to be documented and shared so that other publishers and users 
 
 The [Extension Explorer](../guidance/map/extensions) publishes details of known extensions.
 
-The schema for the standard by default allows for new fields, and does not fail validation of a file which contains unknown fields. 
+The schema for the standard by default allows for new fields, and does not fail validation of a file which contains unknown fields.
+
+It must be possible to access an extension's schema and codelist files by replacing `extension.json` in the extension's URL with a file's path, e.g. `release-schema.json` or `codelists/codelist.csv`. For more information, refer to the Extension Explorer's [guidance on documenting extensions](https://extensions.open-contracting.org/en/publishers/#document).


### PR DESCRIPTION
… paths

partially addresses #1571 

The other page in this repo that references Extensions is https://standard.open-contracting.org/latest/en/guidance/map/extensions/ but all it says is of relevant here is "You can find the [extension template](https://github.com/open-contracting/standard_extension_template) on GitHub. It contains guidance on creating an extension." and while the guidance will be moved there will still be a link to it from the extension template so I don't think we need to alter this sentence.

This PR does not close the linked issue as it still requires updating the extension_explorer repo