### PR TITLE
schema: add finalStatusDate to tender, award, contract

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -215,6 +215,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * [#1519](https://github.com/open-contracting/standard/pull/1519) `Value.amountNet` and `Value.amountGross`
   * [#1490](https://github.com/open-contracting/standard/pull/1490) `contracts.identifiers`
   * [#1679](https://github.com/open-contracting/standard/pull/1679) `Organization.details.classifications`
+  * [#1683](https://github.com/open-contracting/standard/pull/1683) `Tender.finalStatusDate`, `Award.finalStatusDate` and `Contract.finalStatusDate`
 
 * Deprecate some fields:
   * [#1200](https://github.com/open-contracting/standard/pull/1200) `tender.submissionMethod`, because all codes from the `submissionMethod` codelist are deprecated.

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -196,7 +196,7 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * [#1654](https://github.com/open-contracting/standard/pull/1654) `tender.submissionTerms.electronicSubmissionPolicy`
   * [#1421](https://github.com/open-contracting/standard/pull/1421) `tender.standstillPeriod`
   * [#1492](https://github.com/open-contracting/standard/pull/1492) `awards.datePublished`
-  * [#1648](https://github.com/open-contracting/standard/pull/1648) `finalStatus` and `finalStatusDetails` to `Tender`, `Award` and `Contract`
+  * [#1648](https://github.com/open-contracting/standard/pull/1648) [#1683](https://github.com/open-contracting/standard/pull/1683) `finalStatus`, `finalStatusDetails` and `finalStatusDate` to `Tender`, `Award` and `Contract`
   * [#1208](https://github.com/open-contracting/standard/pull/1326) The estimated and maximum values of framework agreeemnts:
     * `tender.maximumValue`. Previously, `tender.value` was used for the maximum value. However, this led to double-counting.
     * `awards.maximumValue`. Previously, `awards.value` was used for the maximum value. However, this led to double-counting.
@@ -215,7 +215,6 @@ Per the [normative and non-normative content and changes policy](../governance/n
   * [#1519](https://github.com/open-contracting/standard/pull/1519) `Value.amountNet` and `Value.amountGross`
   * [#1490](https://github.com/open-contracting/standard/pull/1490) `contracts.identifiers`
   * [#1679](https://github.com/open-contracting/standard/pull/1679) `Organization.details.classifications`
-  * [#1683](https://github.com/open-contracting/standard/pull/1683) `Tender.finalStatusDate`, `Award.finalStatusDate` and `Contract.finalStatusDate`
 
 * Deprecate some fields:
   * [#1200](https://github.com/open-contracting/standard/pull/1200) `tender.submissionMethod`, because all codes from the `submissionMethod` codelist are deprecated.

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -2414,6 +2414,15 @@
             "null"
           ]
         },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the tender reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "procuringEntity": {
           "properties": {
             "name": {
@@ -6363,6 +6372,15 @@
               "null"
             ]
           },
+          "finalStatusDate": {
+            "title": "Final status date",
+            "description": "The date on which the award reached its final status.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
           "date": {
             "title": "Award date",
             "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
@@ -8919,6 +8937,15 @@
               "string",
               "null"
             ]
+          },
+          "finalStatusDate": {
+            "title": "Final status date",
+            "description": "The date on which the contract reached its final status.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
           },
           "dateSigned": {
             "title": "Date concluded",
@@ -15427,6 +15454,15 @@
             "null"
           ]
         },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the tender reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "procuringEntity": {
           "properties": {
             "name": {
@@ -19372,6 +19408,15 @@
             "null"
           ]
         },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the award reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "date": {
           "title": "Award date",
           "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
@@ -21922,6 +21967,15 @@
             "string",
             "null"
           ]
+        },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the contract reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
         },
         "dateSigned": {
           "title": "Date concluded",

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -272,6 +272,15 @@
             "null"
           ]
         },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the tender reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "procuringEntity": {
           "title": "Procuring entity",
           "description": "The organization managing the contracting (or planning) process. If an organization is both a buyer and a procuring entity (as can be the case in simple contracting processes), it should be disclosed using the buyer field, but not this field.",
@@ -614,6 +623,15 @@
             "null"
           ]
         },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the award reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
         "date": {
           "title": "Award date",
           "description": "The date of the contract award. This is usually the date on which a decision to award was made.",
@@ -797,6 +815,15 @@
             "string",
             "null"
           ]
+        },
+        "finalStatusDate": {
+          "title": "Final status date",
+          "description": "The date on which the contract reached its final status.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
         },
         "dateSigned": {
           "title": "Date concluded",

--- a/schema/versioned-release-validation-schema.json
+++ b/schema/versioned-release-validation-schema.json
@@ -289,6 +289,9 @@
         "finalStatusDetails": {
           "$ref": "#/definitions/StringNullVersioned"
         },
+        "finalStatusDate": {
+          "$ref": "#/definitions/StringNullDateTimeVersioned"
+        },
         "procuringEntity": {
           "$ref": "#/definitions/OrganizationReferenceVersionedId"
         },
@@ -734,6 +737,9 @@
         "finalStatusDetails": {
           "$ref": "#/definitions/StringNullVersioned"
         },
+        "finalStatusDate": {
+          "$ref": "#/definitions/StringNullDateTimeVersioned"
+        },
         "date": {
           "$ref": "#/definitions/StringNullDateTimeVersioned"
         },
@@ -943,6 +949,9 @@
         },
         "finalStatusDetails": {
           "$ref": "#/definitions/StringNullVersioned"
+        },
+        "finalStatusDate": {
+          "$ref": "#/definitions/StringNullDateTimeVersioned"
         },
         "dateSigned": {
           "$ref": "#/definitions/StringNullDateTimeVersioned"


### PR DESCRIPTION
closes #1582 `planning.finalStatusDate` already being added in https://github.com/open-contracting/standard/pull/1642