### PR TITLE
Add strict schema docs

### DIFF
--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -7,7 +7,11 @@ In this section you will find the schemas for [releases](release) and [records](
 ```{admonition} Working on a new implementation or looking to improve data quality?
 :class: attention
 
-OCDS offers a voluntary 'strict' version of the release schema, which adds additional validation constraints that are missing from the regular release schema. We plan to add these constraints to the regular schema in the next major version (2.0). In the meantime, you are encouraged to use the strict schema to improve the quality of your data and to increase compatibility with future versions of OCDS. To browse the strict schema, use the [interactive browser](release).
+To improve the quality of your data and to increase compatibility with future versions of OCDS, you are encouraged to use the 'strict' versions of the schemas.
+
+The strict schemas add additional validation rules planned for inclusion in OCDS 2.0. Use of the strict schemas is a voluntary opportunity to improve data quality.
+
+To browse the strict schemas, use the interactive browsers for the [release schema](release), the [record schema](record), the [release package schema](packaging/release_package) and the [record package schema](packaging/record_package).
 ```
 
 The [release schema reference](reference) provides guidance on using each of the [sections](reference.md#release-structure) and [building blocks](reference.md#building-block-reference) in the schema, and the [record schema reference](records_reference) provides additional information on publishing records with compiled and versioned releases.

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -4,6 +4,12 @@ The Open Contracting Data Standard is maintained using JSON Schema.
 
 In this section you will find the schemas for [releases](release) and [records](record) along with the schemas for [packaging](packaging/index.md), which act as envelopes for releases and records.
 
+```{admonition} Working on a new implementation or looking to improve data quality?
+:class: attention
+
+OCDS offers a voluntary 'strict' version of the release schema, which adds additional validation constraints that are missing from the regular release schema. We plan to add these constraints to the regular schema in the next major version (2.0). In the meantime, you are encouraged to use the strict schema to improve the quality of your data and to increase compatibility with future versions of OCDS. To browse the strict schema, use the [interactive browser](release).
+```
+
 The [release schema reference](reference) provides guidance on using each of the [sections](reference.md#release-structure) and [building blocks](reference.md#building-block-reference) in the schema, and the [record schema reference](records_reference) provides additional information on publishing records with compiled and versioned releases.
 
 OCDS data must follow the I-JSON (Internet JSON) specification in [RFC7493](https://tools.ietf.org/html/rfc7493), according to which JSON text must be encoded using [UTF-8](https://en.wikipedia.org/wiki/UTF-8), and which introduces a number of requirements for numbers, objects and dates.

--- a/docs/schema/packaging/record_package.md
+++ b/docs/schema/packaging/record_package.md
@@ -25,7 +25,17 @@ This page presents the record package schema in an interactive browser and in a 
 
 Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section. Required fields are indicated in **bold**. [Deprecated fields](../../governance/deprecation) are omitted.
 
-<script src="../../../_static/docson/public/js/widget.js" data-schema="../../../record-package-schema.json"></script>
+````{tab-set}
+
+```{tab-item} Record package schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../record-package-schema.json"></script>
+```
+
+```{tab-item} Strict record package schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../strict/record-package-schema.json"></script>
+```
+
+````
 
 ## Reference table
 

--- a/docs/schema/packaging/release_package.md
+++ b/docs/schema/packaging/release_package.md
@@ -25,7 +25,17 @@ This page presents the release package schema in an interactive browser and in a
 
 Click on schema elements to expand the tree, or use the '+' icon to expand all elements. Use { } to view the underlying schema for any section. Required fields are indicated in **bold**. [Deprecated fields](../../governance/deprecation) are omitted.
 
-<script src="../../../_static/docson/public/js/widget.js" data-schema="../../../release-package-schema.json"></script>
+````{tab-set}
+
+```{tab-item} Release package schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../release-package-schema.json"></script>
+```
+
+```{tab-item} Strict release package schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../strict/release-package-schema.json"></script>
+```
+
+````
 
 ## Reference table
 

--- a/docs/schema/record.md
+++ b/docs/schema/record.md
@@ -12,4 +12,14 @@ Click on schema elements to expand the tree, or use the '+' icon to expand all e
 This page presents the record schema in an interactive browser. You can also download the canonical version of the record schema as [JSON Schema](../../build/current_lang/record-schema.json) or view it as [tables](records_reference).
 ```
 
+````{tab-set}
+
+```{tab-item} Record schema
 <script src="../../_static/docson/public/js/widget.js" data-schema="../../../record-schema.json"></script>
+```
+
+```{tab-item} Strict record schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../strict/record-schema.json"></script>
+```
+
+````

--- a/docs/schema/release.md
+++ b/docs/schema/release.md
@@ -12,4 +12,14 @@ Click on schema elements to expand the tree, or use the '+' icon to expand all e
 This page presents the release schema in an interactive browser. You can also download the canonical version of the release schema as [JSON Schema](../../build/current_lang/release-schema.json), download it as a [CSV spreadsheet](../../build/current_lang/release-schema.csv), view it as [tables](reference), or access it through the [Field-Level Mapping Template](https://www.open-contracting.org/resources/ocds-field-level-mapping-template/).
 ```
 
+````{tab-set}
+
+```{tab-item} Release schema
 <script src="../../_static/docson/public/js/widget.js" data-schema="../../../release-schema.json"></script>
+```
+
+```{tab-item} Strict release schema
+<script src="../../_static/docson/public/js/widget.js" data-schema="../../../release-schema.json"></script>
+```
+
+````


### PR DESCRIPTION
Closes #1046 

Blocked by https://github.com/open-contracting/standard/pull/1480.

To do:

- [ ] Once #1480 is merged, run pre-commit to add the strict schema files
- [ ] Resolve the Javascript error discussed from https://github.com/open-contracting/standard/pull/1480#issuecomment-1071818457 onwards