### PR TITLE
docs/schema/: create individual pages for all codelists

### DIFF
--- a/docs/schema/codelists.md
+++ b/docs/schema/codelists.md
@@ -2,7 +2,10 @@
 
 Some schema fields refer to codelists, to limit and standardize the possible values of the fields, in order to promote data interoperability.
 
-Codelists can either be open or closed. **Closed codelists** are intended to be comprehensive; for example, the [currency](#currency) codelist covers all currencies in the world. **Open codelists** are intended to be representative, but not comprehensive.
+Codelists can either be open or closed;
+
+* **Closed codelists** are intended to be comprehensive; for example, the [currency](#currency) codelist covers all currencies in the world.
+* **Open codelists** are intended to be representative, but not comprehensive.
 
 Publishers must use the codes in the codelists, unless no code is appropriate. If no code is appropriate and the codelist is **open**, then a publisher may use a new code outside those in the codelist. If no code is appropriate and the codelist is **closed**, then a publisher is encouraged to create an issue in the [OCDS GitHub repository](https://github.com/open-contracting/standard/issues) about adding a new code.
 
@@ -16,58 +19,89 @@ The release schema, in [JSON Schema](../../build/current_lang/release-schema.jso
 
 Codes are case-sensitive, and are generally provided as English language camelCase. Codes must not be translated, though the OCDS team will work with publishers to translate code titles and definitions.
 
-## All Codelists
+[Contract Status](codelists/contractStatus.md)
 
-### [Award Criteria](codelists/awardCriteria.md)
+[Award Criteria](codelists/awardCriteria.md)
 
-### [Award Final Status](codelists/awardFinalStatus.md)
+[Award Final Status](codelists/awardFinalStatus.md)
 
-### [Award Status](codelists/awardStatus.md)
+[Award Status](codelists/awardStatus.md)
 
-### [Classification Scheme](codelists/classificationScheme.md)
+[Classification Scheme](codelists/classificationScheme.md)
 
-### [Contract Final Status](codelists/contractFinalStatus.md)
+[Contract Final Status](codelists/contractFinalStatus.md)
 
-### [Contract Status](codelists/contractStatus.md)
+[Country](codelists/country.md)
 
-### [Country](codelists/country.md)
+[Currency](codelists/currency.md)
 
-### [Currency](codelists/currency.md)
+[Document Type](codelists/documentType.md)
 
-### [Document Type](codelists/documentType.md)
+[Extended Procurement Category](codelists/extendedProcurementCategory.md)
 
-### [Extended Procurement Category](codelists/extendedProcurementCategory.md)
+[Initiation Type](codelists/initiationType.md)
 
-### [Initiation Type](codelists/initiationType.md)
+[Language](codelists/language.md)
 
-### [Language](codelists/language.md)
+[Link Relation Type](codelists/linkRelationType.md)
 
-### [Link Relation Type](codelists/linkRelationType.md)
+[Media Type](codelists/mediaType.md)
 
-### [Media Type](codelists/mediaType.md)
+[Method](codelists/method.md)
 
-### [Method](codelists/method.md)
+[Milestone Status](codelists/milestoneStatus.md)
 
-### [Milestone Status](codelists/milestoneStatus.md)
+[Milestone Type](codelists/milestoneType.md)
 
-### [Milestone Type](codelists/milestoneType.md)
+[Organization Identifier Scheme](codelists/organizationIdentifierScheme.md)
 
-### [Organization Identifier Scheme](codelists/organizationIdentifierScheme.md)
+[Organization Role](codelists/partyRole.md)
 
-### [Organization Role](codelists/partyRole.md)
+[Party Scale](codelists/partyScale.md)
 
-### [Party Scale](codelists/partyScale.md)
+[Procurement Category](codelists/procurementCategory.md)
 
-### [Procurement Category](codelists/procurementCategory.md)
+[Release Tag](codelists/releaseTag.md)
 
-### [Release Tag](codelists/releaseTag.md)
+[Related Process](codelists/relatedProcess.md)
 
-### [Related Process](codelists/relatedProcess.md)
+[Related Process](codelists/relatedProcessScheme.md)
 
-### [Related Process](codelists/relatedProcessScheme.md)
+[Submission Method](codelists/submissionMethod.md)
 
-### [Submission Method](codelists/submissionMethod.md)
+[Tender Final Status](codelists/tenderFinalStatus.md)
 
-### [Tender Final Status](codelists/tenderFinalStatus.md)
+[Tender Status](codelists/tenderStatus.md)
 
-### [Tender Status](codelists/tenderStatus.md)
+```{toctree}
+:hidden:
+
+codelists/awardCriteria
+codelists/awardFinalStatus
+codelists/awardStatus
+codelists/classificationScheme
+codelists/contractFinalStatus
+codelists/contractStatus
+codelists/country
+codelists/currency
+codelists/documentType
+codelists/extendedProcurementCategory
+codelists/initiationType
+codelists/language
+codelists/linkRelationType
+codelists/mediaType
+codelists/method
+codelists/milestoneStatus
+codelists/milestoneType
+codelists/organizationIdentifierScheme
+codelists/partyRole
+codelists/partyScale
+codelists/procurementCategory
+codelists/relatedProcess
+codelists/relatedProcessScheme
+codelists/releaseTag
+codelists/submissionMethod
+codelists/tenderFinalStatus
+codelists/tenderStatus
+codelists/unitClassificationScheme
+```

--- a/docs/schema/codelists.md
+++ b/docs/schema/codelists.md
@@ -16,355 +16,58 @@ The release schema, in [JSON Schema](../../build/current_lang/release-schema.jso
 
 Codes are case-sensitive, and are generally provided as English language camelCase. Codes must not be translated, though the OCDS team will work with publishers to translate code titles and definitions.
 
-## Open Codelists
+## All Codelists
 
-### Release Tag
+### [Award Criteria](codelists/awardCriteria.md)
 
-A contracting (or planning) process can result in a number of releases of information over time. A release must be tagged to indicate whether it is about a planning process or a contracting process and, if it is about the latter, to indicate the stage of the contracting process to which it relates.
+### [Award Final Status](codelists/awardFinalStatus.md)
 
-Additional codes may be used to label releases, based on user needs: for example, to indicate the notice or form to which a release corresponds.
+### [Award Status](codelists/awardStatus.md)
 
-```{versionchanged} 1.1
-Added the 'planningUpdate' code.
-```
+### [Classification Scheme](codelists/classificationScheme.md)
 
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/releaseTag.csv
-```
+### [Contract Final Status](codelists/contractFinalStatus.md)
 
-### Organization Role
+### [Contract Status](codelists/contractStatus.md)
 
-```{versionadded} 1.1
-```
+### [Country](codelists/country.md)
 
-The organizations participating in a contracting (or planning) process are listed in the [parties section](reference.md#parties). In a given process, a single organization can have one or more roles.
+### [Currency](codelists/currency.md)
 
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/partyRole.csv
-```
+### [Document Type](codelists/documentType.md)
 
-### Classification Scheme
+### [Extended Procurement Category](codelists/extendedProcurementCategory.md)
 
-The `classificationScheme` codelist is referenced by the `scheme` field of the `Classification` object, which can be used in multiple contexts. You can find the codes relevant to a given context by filtering the codelist by its `Category` column.
+### [Initiation Type](codelists/initiationType.md)
 
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/classificationScheme.csv
-```
+### [Language](codelists/language.md)
 
-### Unit Classification Scheme
+### [Link Relation Type](codelists/linkRelationType.md)
 
-```{versionadded} 1.1
-```
+### [Media Type](codelists/mediaType.md)
 
-Item quantities can be provided using an established codelist for units of measurement. Codelists might provide human-readable descriptions of units, or symbols for use in input and display interfaces.
+### [Method](codelists/method.md)
 
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/unitClassificationScheme.csv
-```
+### [Milestone Status](codelists/milestoneStatus.md)
 
-### Organization Identifier Scheme
+### [Milestone Type](codelists/milestoneType.md)
 
-![org-id.guide](../_static/png/org-id_logo.png)
+### [Organization Identifier Scheme](codelists/organizationIdentifierScheme.md)
 
-The Organization Identifier Scheme uses the codes from [org-id.guide](http://org-id.guide). The latest version of the codelist can be [downloaded](http://org-id.guide/download.csv) or [browsed](http://org-id.guide) from its website.
+### [Organization Role](codelists/partyRole.md)
 
-To add new codes to the codelist, contact the [Data Support Team](../../support/index).
+### [Party Scale](codelists/partyScale.md)
 
-```{versionchanged} 1.1
-The `organizationIdentifierRegistrationAgency_iati.csv` file was removed. This list was formerly maintained by the International Aid Transparency Initiative.
-```
+### [Procurement Category](codelists/procurementCategory.md)
 
-### Document Type
+### [Release Tag](codelists/releaseTag.md)
 
-The following list describes documents and documentation recommended for publication as part of an open contracting implementation. The codelist indicates the section of an OCDS release they are most likely to be applicable within. 
+### [Related Process](codelists/relatedProcess.md)
 
-The code descriptions are necessarily broad, to cover their usage in a range of contracting (or planning) processes, including for goods, services and works, and in other contexts, such as public private partnerships, infrastructure or concession contracts. 
+### [Related Process](codelists/relatedProcessScheme.md)
 
-Publishers must map their existing document codes to this list, where possible. If using this list within a user interface, publishers can re-write the codelist titles and descriptions appropriately for the context they are being used in. 
+### [Submission Method](codelists/submissionMethod.md)
 
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/documentType.csv
-```
+### [Tender Final Status](codelists/tenderFinalStatus.md)
 
-### Award Criteria
-
-The award criteria codelist describes the basis on which contract awards will be made. 
-
-```{versionchanged} 1.1
-Added all new codes. Deprecated all old codes, which were undefined.
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/awardCriteria.csv
-```
-
-### Submission Method
-
-```{deprecated} 1.2
-```
-
-The submission method codelist is used to identify the mechanism through which a submission can be made. 
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/submissionMethod.csv
-```
-
-### Related Process
-
-```{versionadded} 1.1
-```
-
-```{versionchanged} 1.2
-Added 'parent'. Deprecated 'subContract', 'replacementProcess' and 'renewalProcess'.
-```
-
-```{field-description} ../../build/current_lang/release-schema.json /definitions/RelatedProcess
-```
-
-```{seealso}
-* [Map: Contracting processes and planning processes](../guidance/map/contracting_planning_processes.md)
-* [Map: Framework agreements](../guidance/map/framework_agreements.md)
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/relatedProcess.csv
-```
-
-### Related Process Scheme
-
-```{versionadded} 1.1
-```
-
-The related process scheme describes the kind of identifier used to cross-reference another process. 
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/relatedProcessScheme.csv
-```
-
-### Milestone Type
-
-```{versionadded} 1.1
-```
-
-The milestone block can be used to represent a wide variety of events in the lifetime of a contracting (or planning) process. The milestone type codelist is used to indicate the nature of each milestone.
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/milestoneType.csv
-```
-
-### Extended Procurement Category
-
-```{versionadded} 1.1
-```
-
-The extended procurement category codelist is used to provide additional detail about the focus of a contracting (or planning) process. 
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/extendedProcurementCategory.csv
-```
-
-### Language
-
-```{versionadded} 1.2
-```
-
-The language codelist is used to provide the default language used in text fields and the language of linked documents, using two-letter codes from [ISO639-1](https://id.loc.gov/vocabulary/iso639-1.html).
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/language.csv
-```
-
-### Media Type
-
-```{versionadded} 1.2
-```
-
-The media type codelist is based on the [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) list. The media type codelist adds an exceptional code for printed documents ('offline/print'), and omits any media type that is marked as deprecated or obsolete by IANA.
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/mediaType.csv
-```
-
-### Link Relation Type
-
-```{versionadded} 1.2
-```
-
-The link relation type codelist is based on a subset of the [IANA Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) list.
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/linkRelationType.csv
-```
-
-## Closed Codelists 
-
-### Country
-
-```{versionadded} 1.2
-```
-
-The country codelist is used to provide the country component of an address, using uppercase two-letter codes from [ISO3166-1](https://www.iso.org/iso-3166-country-codes.html). The country codelist adds a user-assigned code for Kosovo ('XK').
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/country.csv
-```
-
-### Initiation Type
-
-```{deprecated} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/initiationType.csv
-```
-
-### Tender Status
-
-```{deprecated} 1.2
-```
-
-```{versionchanged} 1.1
-Added the 'planning' and 'withdrawn' codes.
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/tenderStatus.csv
-```
-
-### Method
-
-The procurement method describes which organizations can submit a bid. The method codelist draws upon [the definitions of open, selective and limited provided by the WTO Government Procurement Agreement](https://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm), and adds an additional 'direct' code for awards without competition.
-
-```{versionchanged} 1.1
-Added the 'direct' code.
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/method.csv
-```
-
-### Procurement Category
-
-```{versionadded} 1.1
-```
-
-The procurement category codelist is used to indicate the **primary** focus of a contracting (or planning) process. Where a contracting (or planning) process covers more than one of the options below, publishers should use the `additionalProcurementCategories` field with an array of entries from the open [extendedProcurementCategory](#extended-procurement-category) codelist.
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/procurementCategory.csv
-```
-
-### Award Status
-
-```{deprecated} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/awardStatus.csv
-```
-
-### Contract Status
-
-```{deprecated} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/contractStatus.csv
-```
-
-### Milestone Status
-
-```{versionchanged} 1.1
-Added the 'scheduled' code.
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/milestoneStatus.csv
-```
-
-### Currency
-
-```{versionadded} 1.1
-```
-
-The currency for each amount must be specified using the uppercase 3-letter currency code from [ISO4217](https://www.iso.org/iso-4217-currency-codes.html).
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/currency.csv
-```
-
-### Party Scale
-
-```{versionadded} 1.2
-```
-
-The party scale codelist is used to indicate the size or scale of an organization, in particular commercial enterprises or economic operators.
-
-The codes in the codelist do not have precise definitions. Instead, they defer to local laws and regulations, for example:
-
-* [OECD: Small and Medium-Sized Enterprises (SMEs) definition](https://stats.oecd.org/glossary/detail.asp?ID=3123)
-* [European Commission: What is an SME?](https://ec.europa.eu/growth/smes/sme-definition_en)
-
-For small and medium-sized enterprises, if you can distinguish between the two sizes, use the 'small' and 'medium' codes. Otherwise, use the 'sme' code.
-
-For self-employed individuals and sole traders, if you can distinguish them from micro enterprises, use the 'selfEmployed' code. Otherwise, use the 'micro' code.
-
-For enterprises without employees, use the 'micro' code.
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/partyScale.csv
-```
-
-### Tender Final Status
-
-```{versionadded} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/tenderFinalStatus.csv
-```
-
-### Award Final Status
-
-```{versionadded} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/awardFinalStatus.csv
-```
-
-### Contract Final Status
-
-```{versionadded} 1.2
-```
-
-```{csv-table-no-translate}
-:header-rows: 1
-:file: ../../build/current_lang/codelists/contractFinalStatus.csv
-```
+### [Tender Status](codelists/tenderStatus.md)

--- a/docs/schema/codelists.md
+++ b/docs/schema/codelists.md
@@ -4,7 +4,7 @@ Some schema fields refer to codelists, to limit and standardize the possible val
 
 Codelists can either be open or closed;
 
-* **Closed codelists** are intended to be comprehensive; for example, the [currency](#currency) codelist covers all currencies in the world.
+* **Closed codelists** are intended to be comprehensive; for example, the [currency](codelists/currency.md) codelist covers all currencies in the world.
 * **Open codelists** are intended to be representative, but not comprehensive.
 
 Publishers must use the codes in the codelists, unless no code is appropriate. If no code is appropriate and the codelist is **open**, then a publisher may use a new code outside those in the codelist. If no code is appropriate and the codelist is **closed**, then a publisher is encouraged to create an issue in the [OCDS GitHub repository](https://github.com/open-contracting/standard/issues) about adding a new code.
@@ -18,60 +18,6 @@ If you use new codes outside those in an open codelist, please document the code
 The release schema, in [JSON Schema](../../build/current_lang/release-schema.json), has a `codelist` property to indicate the <a href="../../codelists/">CSV File</a> that defines the codes in the codelist (shown as tables below). It also has an `openCodelist` property, to indicate whether the codelist is open or closed.
 
 Codes are case-sensitive, and are generally provided as English language camelCase. Codes must not be translated, though the OCDS team will work with publishers to translate code titles and definitions.
-
-[Contract Status](codelists/contractStatus.md)
-
-[Award Criteria](codelists/awardCriteria.md)
-
-[Award Final Status](codelists/awardFinalStatus.md)
-
-[Award Status](codelists/awardStatus.md)
-
-[Classification Scheme](codelists/classificationScheme.md)
-
-[Contract Final Status](codelists/contractFinalStatus.md)
-
-[Country](codelists/country.md)
-
-[Currency](codelists/currency.md)
-
-[Document Type](codelists/documentType.md)
-
-[Extended Procurement Category](codelists/extendedProcurementCategory.md)
-
-[Initiation Type](codelists/initiationType.md)
-
-[Language](codelists/language.md)
-
-[Link Relation Type](codelists/linkRelationType.md)
-
-[Media Type](codelists/mediaType.md)
-
-[Method](codelists/method.md)
-
-[Milestone Status](codelists/milestoneStatus.md)
-
-[Milestone Type](codelists/milestoneType.md)
-
-[Organization Identifier Scheme](codelists/organizationIdentifierScheme.md)
-
-[Organization Role](codelists/partyRole.md)
-
-[Party Scale](codelists/partyScale.md)
-
-[Procurement Category](codelists/procurementCategory.md)
-
-[Release Tag](codelists/releaseTag.md)
-
-[Related Process](codelists/relatedProcess.md)
-
-[Related Process](codelists/relatedProcessScheme.md)
-
-[Submission Method](codelists/submissionMethod.md)
-
-[Tender Final Status](codelists/tenderFinalStatus.md)
-
-[Tender Status](codelists/tenderStatus.md)
 
 ```{toctree}
 :hidden:
@@ -105,3 +51,69 @@ codelists/tenderFinalStatus
 codelists/tenderStatus
 codelists/unitClassificationScheme
 ```
+
+## Uncategorized
+
+[Release Tag](codelists/releaseTag.md)
+
+[Classification Scheme](codelists/classificationScheme.md)
+
+[Document Type](codelists/documentType.md)
+
+[Milestone Type](codelists/milestoneType.md)
+
+[Initiation Type](codelists/initiationType.md) {bdg-danger}`deprecated`
+
+## Status
+
+[Tender Final Status](codelists/tenderFinalStatus.md)
+
+[Award Final Status](codelists/awardFinalStatus.md)
+
+[Contract Final Status](codelists/contractFinalStatus.md)
+
+[Milestone Status](codelists/milestoneStatus.md)
+
+[Tender Status](codelists/tenderStatus.md) {bdg-danger}`deprecated`
+
+[Award Status](codelists/awardStatus.md) {bdg-danger}`deprecated`
+
+[Contract Status](codelists/contractStatus.md) {bdg-danger}`deprecated`
+
+## Organization
+
+[Organization Role](codelists/partyRole.md)
+
+[Organization Identifier Scheme](codelists/organizationIdentifierScheme.md)
+
+[Party Scale](codelists/partyScale.md)
+
+## Tender
+
+[Method](codelists/method.md)
+
+[Procurement Category](codelists/procurementCategory.md)
+
+[Extended Procurement Category](codelists/extendedProcurementCategory.md)
+
+[Award Criteria](codelists/awardCriteria.md)
+
+[Submission Method](codelists/submissionMethod.md) {bdg-danger}`deprecated`
+
+## Related process
+
+[Related Process](codelists/relatedProcess.md)
+
+[Related Process](codelists/relatedProcessScheme.md)
+
+## External
+
+[Country](codelists/country.md) ([ISO 3166-1 alpha-2](https://www.iso.org/iso-3166-country-codes.html))
+
+[Currency](codelists/currency.md) ([ISO4217](https://www.iso.org/iso-4217-currency-codes.html))
+
+[Language](codelists/language.md) ([ISO639-1](https://id.loc.gov/vocabulary/iso639-1.html))
+
+[Link Relation Type](codelists/linkRelationType.md) ([IANA Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml))
+
+[Media Type](codelists/mediaType.md) ([IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml))

--- a/docs/schema/codelists/awardCriteria.md
+++ b/docs/schema/codelists/awardCriteria.md
@@ -1,6 +1,6 @@
 # Award Criteria
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 The award criteria codelist describes the basis on which contract awards will be made.
 

--- a/docs/schema/codelists/awardCriteria.md
+++ b/docs/schema/codelists/awardCriteria.md
@@ -1,0 +1,14 @@
+# Award Criteria
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+The award criteria codelist describes the basis on which contract awards will be made.
+
+```{versionchanged} 1.1
+Added all new codes. Deprecated all old codes, which were undefined.
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/awardCriteria.csv
+```

--- a/docs/schema/codelists/awardFinalStatus.md
+++ b/docs/schema/codelists/awardFinalStatus.md
@@ -1,6 +1,6 @@
 # Award Final Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/awardFinalStatus.md
+++ b/docs/schema/codelists/awardFinalStatus.md
@@ -1,0 +1,11 @@
+# Award Final Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/awardFinalStatus.csv
+```

--- a/docs/schema/codelists/awardStatus.md
+++ b/docs/schema/codelists/awardStatus.md
@@ -1,0 +1,11 @@
+# Award Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{deprecated} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/awardStatus.csv
+```

--- a/docs/schema/codelists/awardStatus.md
+++ b/docs/schema/codelists/awardStatus.md
@@ -1,6 +1,6 @@
 # Award Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{deprecated} 1.2
 ```

--- a/docs/schema/codelists/classificationScheme.md
+++ b/docs/schema/codelists/classificationScheme.md
@@ -1,6 +1,6 @@
 # Classification Scheme
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 The `classificationScheme` codelist is referenced by the `scheme` field of the `Classification` object, which can be used in multiple contexts. You can find the codes relevant to a given context by filtering the codelist by its `Category` column.
 

--- a/docs/schema/codelists/classificationScheme.md
+++ b/docs/schema/codelists/classificationScheme.md
@@ -1,0 +1,10 @@
+# Classification Scheme
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+The `classificationScheme` codelist is referenced by the `scheme` field of the `Classification` object, which can be used in multiple contexts. You can find the codes relevant to a given context by filtering the codelist by its `Category` column.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/classificationScheme.csv
+```

--- a/docs/schema/codelists/contractFinalStatus.md
+++ b/docs/schema/codelists/contractFinalStatus.md
@@ -1,0 +1,11 @@
+# Contract Final Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/contractFinalStatus.csv
+```

--- a/docs/schema/codelists/contractFinalStatus.md
+++ b/docs/schema/codelists/contractFinalStatus.md
@@ -1,6 +1,6 @@
 # Contract Final Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/contractStatus.md
+++ b/docs/schema/codelists/contractStatus.md
@@ -1,0 +1,11 @@
+# Contract Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{deprecated} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/contractStatus.csv
+```

--- a/docs/schema/codelists/contractStatus.md
+++ b/docs/schema/codelists/contractStatus.md
@@ -1,6 +1,6 @@
 # Contract Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{deprecated} 1.2
 ```

--- a/docs/schema/codelists/country.md
+++ b/docs/schema/codelists/country.md
@@ -1,0 +1,13 @@
+# Country
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+The country codelist is used to provide the country component of an address, using uppercase two-letter codes from [ISO3166-1](https://www.iso.org/iso-3166-country-codes.html). The country codelist adds a user-assigned code for Kosovo ('XK').
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/country.csv
+```

--- a/docs/schema/codelists/country.md
+++ b/docs/schema/codelists/country.md
@@ -1,6 +1,6 @@
 # Country
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/currency.md
+++ b/docs/schema/codelists/currency.md
@@ -1,6 +1,6 @@
 # Currency
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/currency.md
+++ b/docs/schema/codelists/currency.md
@@ -1,0 +1,13 @@
+# Currency
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The currency for each amount must be specified using the uppercase 3-letter currency code from [ISO4217](https://www.iso.org/iso-4217-currency-codes.html).
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/currency.csv
+```

--- a/docs/schema/codelists/documentType.md
+++ b/docs/schema/codelists/documentType.md
@@ -1,0 +1,14 @@
+# Document Type
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+The following list describes documents and documentation recommended for publication as part of an open contracting implementation. The codelist indicates the section of an OCDS release they are most likely to be applicable within.
+
+The code descriptions are necessarily broad, to cover their usage in a range of contracting (or planning) processes, including for goods, services and works, and in other contexts, such as public private partnerships, infrastructure or concession contracts.
+
+Publishers must map their existing document codes to this list, where possible. If using this list within a user interface, publishers can re-write the codelist titles and descriptions appropriately for the context they are being used in.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/documentType.csv
+```

--- a/docs/schema/codelists/documentType.md
+++ b/docs/schema/codelists/documentType.md
@@ -1,6 +1,6 @@
 # Document Type
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 The following list describes documents and documentation recommended for publication as part of an open contracting implementation. The codelist indicates the section of an OCDS release they are most likely to be applicable within.
 

--- a/docs/schema/codelists/extendedProcurementCategory.md
+++ b/docs/schema/codelists/extendedProcurementCategory.md
@@ -1,6 +1,6 @@
 # Extended Procurement Category
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/extendedProcurementCategory.md
+++ b/docs/schema/codelists/extendedProcurementCategory.md
@@ -1,0 +1,13 @@
+# Extended Procurement Category
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The extended procurement category codelist is used to provide additional detail about the focus of a contracting (or planning) process.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/extendedProcurementCategory.csv
+```

--- a/docs/schema/codelists/initiationType.md
+++ b/docs/schema/codelists/initiationType.md
@@ -1,6 +1,6 @@
 # Initiation Type
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{deprecated} 1.2
 ```

--- a/docs/schema/codelists/initiationType.md
+++ b/docs/schema/codelists/initiationType.md
@@ -1,0 +1,11 @@
+# Initiation Type
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{deprecated} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/initiationType.csv
+```

--- a/docs/schema/codelists/language.md
+++ b/docs/schema/codelists/language.md
@@ -1,0 +1,13 @@
+# Language
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+The language codelist is used to provide the default language used in text fields and the language of linked documents, using two-letter codes from [ISO639-1](https://id.loc.gov/vocabulary/iso639-1.html).
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/language.csv
+```

--- a/docs/schema/codelists/language.md
+++ b/docs/schema/codelists/language.md
@@ -1,6 +1,6 @@
 # Language
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/linkRelationType.md
+++ b/docs/schema/codelists/linkRelationType.md
@@ -1,0 +1,13 @@
+# Link Relation Type
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+The link relation type codelist is based on a subset of the [IANA Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml) list.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/linkRelationType.csv
+```

--- a/docs/schema/codelists/linkRelationType.md
+++ b/docs/schema/codelists/linkRelationType.md
@@ -1,6 +1,6 @@
 # Link Relation Type
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/mediaType.md
+++ b/docs/schema/codelists/mediaType.md
@@ -1,0 +1,13 @@
+# Media Type
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+The media type codelist is based on the [IANA Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) list. The media type codelist adds an exceptional code for printed documents ('offline/print'), and omits any media type that is marked as deprecated or obsolete by IANA.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/mediaType.csv
+```

--- a/docs/schema/codelists/mediaType.md
+++ b/docs/schema/codelists/mediaType.md
@@ -1,6 +1,6 @@
 # Media Type
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/method.md
+++ b/docs/schema/codelists/method.md
@@ -1,6 +1,6 @@
 # Method
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 The procurement method describes which organizations can submit a bid. The method codelist draws upon [the definitions of open, selective and limited provided by the WTO Government Procurement Agreement](https://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm), and adds an additional 'direct' code for awards without competition.
 

--- a/docs/schema/codelists/method.md
+++ b/docs/schema/codelists/method.md
@@ -1,0 +1,14 @@
+# Method
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+The procurement method describes which organizations can submit a bid. The method codelist draws upon [the definitions of open, selective and limited provided by the WTO Government Procurement Agreement](https://www.wto.org/english/docs_e/legal_e/rev-gpr-94_01_e.htm), and adds an additional 'direct' code for awards without competition.
+
+```{versionchanged} 1.1
+Added the 'direct' code.
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/method.csv
+```

--- a/docs/schema/codelists/milestoneStatus.md
+++ b/docs/schema/codelists/milestoneStatus.md
@@ -1,0 +1,12 @@
+# Milestone Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionchanged} 1.1
+Added the 'scheduled' code.
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/milestoneStatus.csv
+```

--- a/docs/schema/codelists/milestoneStatus.md
+++ b/docs/schema/codelists/milestoneStatus.md
@@ -1,6 +1,6 @@
 # Milestone Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionchanged} 1.1
 Added the 'scheduled' code.

--- a/docs/schema/codelists/milestoneType.md
+++ b/docs/schema/codelists/milestoneType.md
@@ -1,0 +1,13 @@
+# Milestone Type
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The milestone block can be used to represent a wide variety of events in the lifetime of a contracting (or planning) process. The milestone type codelist is used to indicate the nature of each milestone.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/milestoneType.csv
+```

--- a/docs/schema/codelists/milestoneType.md
+++ b/docs/schema/codelists/milestoneType.md
@@ -1,6 +1,6 @@
 # Milestone Type
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/organizationIdentifierScheme.md
+++ b/docs/schema/codelists/organizationIdentifierScheme.md
@@ -2,7 +2,7 @@
 
 {bdg-link-secondary}`Open<../../codelists/#codelists>`
 
-![org-id.guide](../_static/png/org-id_logo.png)
+![org-id.guide](../../_static/png/org-id_logo.png)
 
 The Organization Identifier Scheme uses the codes from [org-id.guide](http://org-id.guide). The latest version of the codelist can be [downloaded](http://org-id.guide/download.csv) or [browsed](http://org-id.guide) from its website.
 

--- a/docs/schema/codelists/organizationIdentifierScheme.md
+++ b/docs/schema/codelists/organizationIdentifierScheme.md
@@ -1,0 +1,13 @@
+# Organization Identifier Scheme
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+![org-id.guide](../_static/png/org-id_logo.png)
+
+The Organization Identifier Scheme uses the codes from [org-id.guide](http://org-id.guide). The latest version of the codelist can be [downloaded](http://org-id.guide/download.csv) or [browsed](http://org-id.guide) from its website.
+
+To add new codes to the codelist, contact the [Data Support Team](../../support/index).
+
+```{versionchanged} 1.1
+The `organizationIdentifierRegistrationAgency_iati.csv` file was removed. This list was formerly maintained by the International Aid Transparency Initiative.
+```

--- a/docs/schema/codelists/organizationIdentifierScheme.md
+++ b/docs/schema/codelists/organizationIdentifierScheme.md
@@ -1,6 +1,6 @@
 # Organization Identifier Scheme
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ![org-id.guide](../../_static/png/org-id_logo.png)
 

--- a/docs/schema/codelists/partyRole.md
+++ b/docs/schema/codelists/partyRole.md
@@ -1,6 +1,6 @@
 # Organization Role
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/partyRole.md
+++ b/docs/schema/codelists/partyRole.md
@@ -1,0 +1,13 @@
+# Organization Role
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The organizations participating in a contracting (or planning) process are listed in the [parties section](../reference.md#parties). In a given process, a single organization can have one or more roles.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/partyRole.csv
+```

--- a/docs/schema/codelists/partyScale.md
+++ b/docs/schema/codelists/partyScale.md
@@ -1,0 +1,24 @@
+# Party Scale
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+The party scale codelist is used to indicate the size or scale of an organization, in particular commercial enterprises or economic operators.
+
+The codes in the codelist do not have precise definitions. Instead, they defer to local laws and regulations, for example:
+
+* [OECD: Small and Medium-Sized Enterprises (SMEs) definition](https://stats.oecd.org/glossary/detail.asp?ID=3123)
+* [European Commission: What is an SME?](https://ec.europa.eu/growth/smes/sme-definition_en)
+
+For small and medium-sized enterprises, if you can distinguish between the two sizes, use the 'small' and 'medium' codes. Otherwise, use the 'sme' code.
+
+For self-employed individuals and sole traders, if you can distinguish them from micro enterprises, use the 'selfEmployed' code. Otherwise, use the 'micro' code.
+
+For enterprises without employees, use the 'micro' code.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/partyScale.csv
+```

--- a/docs/schema/codelists/partyScale.md
+++ b/docs/schema/codelists/partyScale.md
@@ -1,6 +1,6 @@
 # Party Scale
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/procurementCategory.md
+++ b/docs/schema/codelists/procurementCategory.md
@@ -1,6 +1,6 @@
 # Procurement Category
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/procurementCategory.md
+++ b/docs/schema/codelists/procurementCategory.md
@@ -1,0 +1,13 @@
+# Procurement Category
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The procurement category codelist is used to indicate the **primary** focus of a contracting (or planning) process. Where a contracting (or planning) process covers more than one of the options below, publishers should use the `additionalProcurementCategories` field with an array of entries from the open [extendedProcurementCategory](extendedProcurementCategory.md) codelist.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/procurementCategory.csv
+```

--- a/docs/schema/codelists/relatedProcess.md
+++ b/docs/schema/codelists/relatedProcess.md
@@ -1,6 +1,6 @@
 # Related Process
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/relatedProcess.md
+++ b/docs/schema/codelists/relatedProcess.md
@@ -1,0 +1,23 @@
+# Related Process
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+```{versionchanged} 1.2
+Added 'parent'. Deprecated 'subContract', 'replacementProcess' and 'renewalProcess'.
+```
+
+```{field-description} ../../../build/current_lang/release-schema.json /definitions/RelatedProcess
+```
+
+```{seealso}
+* [Map: Contracting processes and planning processes](../../guidance/map/contracting_planning_processes.md)
+* [Map: Framework agreements](../../guidance/map/framework_agreements.md)
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/relatedProcess.csv
+```

--- a/docs/schema/codelists/relatedProcessScheme.md
+++ b/docs/schema/codelists/relatedProcessScheme.md
@@ -1,0 +1,13 @@
+# Related Process Scheme
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+The related process scheme describes the kind of identifier used to cross-reference another process.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/relatedProcessScheme.csv
+```

--- a/docs/schema/codelists/relatedProcessScheme.md
+++ b/docs/schema/codelists/relatedProcessScheme.md
@@ -1,6 +1,6 @@
 # Related Process Scheme
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/releaseTag.md
+++ b/docs/schema/codelists/releaseTag.md
@@ -1,6 +1,6 @@
 # Release Tag
 
-{bdg-link-secondary}`Open<../../codelists/#open-codelists>`
+{bdg-link-secondary}`open<../../codelists/#open-codelists>`
 
 A contracting (or planning) process can result in a number of releases of information over time. A release must be tagged to indicate whether it is about a planning process or a contracting process and, if it is about the latter, to indicate the stage of the contracting process to which it relates.
 

--- a/docs/schema/codelists/releaseTag.md
+++ b/docs/schema/codelists/releaseTag.md
@@ -1,0 +1,16 @@
+# Release Tag
+
+{bdg-link-secondary}`Open<../../codelists/#open-codelists>`
+
+A contracting (or planning) process can result in a number of releases of information over time. A release must be tagged to indicate whether it is about a planning process or a contracting process and, if it is about the latter, to indicate the stage of the contracting process to which it relates.
+
+Additional codes may be used to label releases, based on user needs: for example, to indicate the notice or form to which a release corresponds.
+
+```{versionchanged} 1.1
+Added the 'planningUpdate' code.
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/releaseTag.csv
+```

--- a/docs/schema/codelists/submissionMethod.md
+++ b/docs/schema/codelists/submissionMethod.md
@@ -1,6 +1,6 @@
 # Submission Method
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{deprecated} 1.2
 ```

--- a/docs/schema/codelists/submissionMethod.md
+++ b/docs/schema/codelists/submissionMethod.md
@@ -1,0 +1,13 @@
+# Submission Method
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{deprecated} 1.2
+```
+
+The submission method codelist is used to identify the mechanism through which a submission can be made. 
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/submissionMethod.csv
+```

--- a/docs/schema/codelists/tenderFinalStatus.md
+++ b/docs/schema/codelists/tenderFinalStatus.md
@@ -1,0 +1,11 @@
+# Tender Final Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{versionadded} 1.2
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/tenderFinalStatus.csv
+```

--- a/docs/schema/codelists/tenderFinalStatus.md
+++ b/docs/schema/codelists/tenderFinalStatus.md
@@ -1,6 +1,6 @@
 # Tender Final Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{versionadded} 1.2
 ```

--- a/docs/schema/codelists/tenderStatus.md
+++ b/docs/schema/codelists/tenderStatus.md
@@ -1,0 +1,15 @@
+# Tender Status
+
+{bdg-link-primary}`Closed<../../codelists/#codelists>`
+
+```{deprecated} 1.2
+```
+
+```{versionchanged} 1.1
+Added the 'planning' and 'withdrawn' codes.
+```
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/tenderStatus.csv
+```

--- a/docs/schema/codelists/tenderStatus.md
+++ b/docs/schema/codelists/tenderStatus.md
@@ -1,6 +1,6 @@
 # Tender Status
 
-{bdg-link-primary}`Closed<../../codelists/#codelists>`
+{bdg-link-primary}`closed<../../codelists/#codelists>`
 
 ```{deprecated} 1.2
 ```

--- a/docs/schema/codelists/unitClassificationScheme.md
+++ b/docs/schema/codelists/unitClassificationScheme.md
@@ -1,6 +1,6 @@
 # Unit Classification Scheme
 
-{bdg-link-secondary}`Open<../../codelists/#codelists>`
+{bdg-link-secondary}`open<../../codelists/#codelists>`
 
 ```{versionadded} 1.1
 ```

--- a/docs/schema/codelists/unitClassificationScheme.md
+++ b/docs/schema/codelists/unitClassificationScheme.md
@@ -1,0 +1,13 @@
+# Unit Classification Scheme
+
+{bdg-link-secondary}`Open<../../codelists/#codelists>`
+
+```{versionadded} 1.1
+```
+
+Item quantities can be provided using an established codelist for units of measurement. Codelists might provide human-readable descriptions of units, or symbols for use in input and display interfaces.
+
+```{csv-table-no-translate}
+:header-rows: 1
+:file: ../../../build/current_lang/codelists/unitClassificationScheme.csv
+```


### PR DESCRIPTION
closes #1405 

- [x] Move codelists to individual pages
- [x] Add a [badge](https://sphinx-design.readthedocs.io/en/latest/badges_buttons.html#badges) below each codelist page title to indicate whether the codelist is open or closed. The badges can link to the sections of the codelist landing page that explain open and closed codelists.
- [x] Order the codelist pages alphabetically in the navigation
- [x] Propose a grouping and ordering for the links from the codelist landing page to the individual codelist pages

Will wait for https://github.com/open-contracting/standard/pull/1660 and https://github.com/open-contracting/standard/pull/1680 to be merged prior to fixing links broken by this PR and then converting it from draft