### PR TITLE
schema/reference.md: remmove reference to contracts.relatedProcesses

### DIFF
--- a/docs/schema/reference.md
+++ b/docs/schema/reference.md
@@ -669,10 +669,10 @@ In OCDS each contracting process can have only one tender stage. There are a num
 
 * When one planning process results in many tenders;
 * When a contract is awarded following two distinct, but related, tender processes, such as in national frameworks with locally run mini-competitions;
-* When a contract results in the award of sub-contracts - and those sub-contracts are also tracked using OCDS;
-* When a contract is coming up for renewal or replacement, and there is a contracting process to award  the renewal/replacement contract;
+* When there is a contracting process that aims to renew or replace a previously awarded contract;
+* When a contracting process is a second attempt to conclude a previous, unsuccessful contracting process;
 
-In all these cases, the `relatedProcess` block should be used to cross-reference between the relevant contracting processes using their `ocid`.
+In all these cases, the `RelatedProcess` subschema should be used to cross-reference back to the preceding process using its `ocid`.
 
 ````{admonition} Example
 :class: hint
@@ -687,17 +687,17 @@ In all these cases, the `relatedProcess` block should be used to cross-reference
 :pointer: /definitions/RelatedProcess
 ```
 
-A related process can be declared at two points in an OCDS release.
+A related process may be declared at the release level in an OCDS release, pointing back to:
 
-**(1) At the release level** - used to point backwards to prior processes, such as planning or framework establishment.
+* prior processes, such as planning or framework establishment.
 
-**(2) At the contract level** - used to point onward to sub-contracts, renewal or replacement processes that relate solely to the particular contract the field appears in.
+* prior contracts that this process is extending, renewing, repeating or replacing.
+
+If the related process is a planning process, `relationship` should be set to 'planning' and the `releaseTag` in the linked release should include 'planning'.
 
 As well as providing this machine-readable link between processes, publishers may also provide links to human-readable documentation in the relevant `documents` blocks. For example:
 
-* When recording a `release/relatedProcess` pointing to the ocid of the planning process that resulted in a tender, a `tender/documents` entry with a `documentType` of 'procurementPlan' and a link to web pages about the procurement plan could be provided;
-* When recording a `contract/relatedProcess` pointing to the ocid of a  sub-contracting process, a `contract/documents` entry with a `documentType` of 'subContract' and a title that describes it as the subcontracting process, could be provided;
-* When recording a `contract/relatedProcess` pointing to the ocid of a contracting process to renew a given contract, a `contract/documents` entry with a `documentType` of 'tenderNotice' and a title that describes it as the successor process, could be provided;
+* When recording a `relatedProcess` pointing to the ocid of the planning process that resulted in a tender, a `tender/documents` entry with a `documentType` of 'procurementPlan' and a link to web pages about the procurement plan could be provided;
 
 ### Location
 

--- a/docs/schema/reference.md
+++ b/docs/schema/reference.md
@@ -670,9 +670,9 @@ A `RelatedProcess` is defined as:
 ```{field-description} ../../build/current_lang/release-schema.json /definitions/RelatedProcess
 ```
 
-The [Related Process](codelists.md#related-process) codelist defines the possible types of relationship. Contracting processes should refer to related processes using the code in the codelist.
+The [Related Process](codelists.md#related-process) codelist defines the possible types of relationship. Contracting processes should refer to related processes using the codes in the codelist.
 
-As well as providing this machine-readable link between processes, publishers may also provide links to human-readable documentation in the relevant `documents` blocks. For example, when a contracting process refers to a planning process, a link to the procurement plan can be provided in `tender/documents`.
+As well as providing a machine-readable link between processes, publishers may also provide links to human-readable documentation in the relevant `documents` array. For example, when a contracting process refers to a planning process, a link to the procurement plan can be provided in `tender/documents`.
 
 ````{admonition} Example
 :class: hint

--- a/docs/schema/reference.md
+++ b/docs/schema/reference.md
@@ -665,14 +665,14 @@ Support for exchange rates can be provided using extensions.
 
 ### RelatedProcess
 
-In OCDS each contracting process can have only one tender stage. There are a number of cases where it is important to know about related contracting processes, including:
+A `RelatedProcess` is defined as:
 
-* When one planning process results in many tenders;
-* When a contract is awarded following two distinct, but related, tender processes, such as in national frameworks with locally run mini-competitions;
-* When there is a contracting process that aims to renew or replace a previously awarded contract;
-* When a contracting process is a second attempt to conclude a previous, unsuccessful contracting process;
+```{field-description} ../../build/current_lang/release-schema.json /definitions/RelatedProcess
+```
 
-In all these cases, the `RelatedProcess` subschema should be used to cross-reference back to the preceding process using its `ocid`.
+The [Related Process](codelists.md#related-process) codelist defines the possible types of relationship. Contracting processes should refer to related processes using the code in the codelist.
+
+As well as providing this machine-readable link between processes, publishers may also provide links to human-readable documentation in the relevant `documents` blocks. For example, when a contracting process refers to a planning process, a link to the procurement plan can be provided in `tender/documents`.
 
 ````{admonition} Example
 :class: hint
@@ -686,18 +686,6 @@ In all these cases, the `RelatedProcess` subschema should be used to cross-refer
 ```{jsonschema} ../../build/current_lang/release-schema.json
 :pointer: /definitions/RelatedProcess
 ```
-
-A related process may be declared at the release level in an OCDS release, pointing back to:
-
-* prior processes, such as planning or framework establishment.
-
-* prior contracts that this process is extending, renewing, repeating or replacing.
-
-If the related process is a planning process, `relationship` should be set to 'planning' and the `releaseTag` in the linked release should include 'planning'.
-
-As well as providing this machine-readable link between processes, publishers may also provide links to human-readable documentation in the relevant `documents` blocks. For example:
-
-* When recording a `relatedProcess` pointing to the ocid of the planning process that resulted in a tender, a `tender/documents` entry with a `documentType` of 'procurementPlan' and a link to web pages about the procurement plan could be provided;
 
 ### Location
 

--- a/schema/dereferenced-release-schema.json
+++ b/schema/dereferenced-release-schema.json
@@ -15821,7 +15821,7 @@
           "relatedProcesses": {
             "uniqueItems": true,
             "items": {
-              "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+              "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
               "type": "object",
               "title": "Related Process",
               "properties": {
@@ -16677,7 +16677,7 @@
     "relatedProcesses": {
       "uniqueItems": true,
       "items": {
-        "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+        "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
         "type": "object",
         "title": "Related Process",
         "properties": {
@@ -16736,7 +16736,7 @@
           }
         }
       },
-      "description": "References to related, preceding contracting (or planning) processes. This information concerns the contracting process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+      "description": "References to related, preceding contracting (or planning) processes. This information concerns the contracting process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
       "title": "Related processes",
       "type": "array"
     },
@@ -31417,7 +31417,7 @@
         "relatedProcesses": {
           "uniqueItems": true,
           "items": {
-            "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+            "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
             "type": "object",
             "title": "Related Process",
             "properties": {
@@ -40875,7 +40875,7 @@
       }
     },
     "RelatedProcess": {
-      "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+      "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
       "type": "object",
       "title": "Related Process",
       "properties": {

--- a/schema/release-schema.json
+++ b/schema/release-schema.json
@@ -114,7 +114,7 @@
       "items": {
         "$ref": "#/definitions/RelatedProcess"
       },
-      "description": "References to related, preceding contracting (or planning) processes. This information concerns the contracting process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+      "description": "References to related, preceding contracting (or planning) processes. This information concerns the contracting process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
       "title": "Related processes",
       "type": "array"
     },
@@ -2682,7 +2682,7 @@
       }
     },
     "RelatedProcess": {
-      "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process may refer to its planning process(es). In multi-stage procedures (e.g. framework agreements with reopening of competition), the contracting process for a later stage may refer to the contracting process for the first stage.",
+      "description": "A reference to a related, preceding contracting (or planning) process. For example, the contracting process should refer to its planning process(es). In multi-stage procedures (for example, framework agreements with reopening of competition), the contracting process for a later stage should refer to the contracting process for the first stage.",
       "type": "object",
       "title": "Related Process",
       "properties": {


### PR DESCRIPTION
closes #1713 

~~The language referring to "tender processes" will be covered by https://github.com/open-contracting/standard/issues/1639~~ no longer relevant as these references have been removed entirely